### PR TITLE
[KNI] fix repo's url in verify-commits.sh script

### DIFF
--- a/.github/hooks/commit-msg
+++ b/.github/hooks/commit-msg
@@ -5,7 +5,7 @@ function enforce_commit_msg()
   local cmtmsg="$1"
   if [[ $cmtmsg != \[KNI\]* ]]; then
     echo "commit message $cmtmsg not formatted correctly, please refer to \
-     https://github.com/Tal-or/scheduler-plugins/blob/master/RESYNC.md#patching-openshift-kni-specific-commits"
+     https://github.com/openshift-kni/scheduler-plugins/blob/master/RESYNC.md#patching-openshift-kni-specific-commits"
     exit 1
   fi
 }

--- a/hack/verify-commits.sh
+++ b/hack/verify-commits.sh
@@ -17,7 +17,7 @@ fi
 if [[ -z "$UPSTREAM_COMMIT" ]]; then
 	# CI=true is set by prow as a way to detect we are running under the ci
 	if [[ -n "$CI" ]]; then
-		latest_upstream_commit=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/Tal-or/scheduler-plugins/commits?per_page=1 | jq -r '.[0].sha')
+		latest_upstream_commit=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/openshift-kni/scheduler-plugins/commits?per_page=1 | jq -r '.[0].sha')
 	else
 		if [[ -z "$UPSTREAM_BRANCH" ]]; then
 			latest_upstream_commit="origin/master"


### PR DESCRIPTION
since we transfer the repo under the openshift-kni org, we need to set the url accordingly

Signed-off-by: Talor Itzhak <titzhak@redhat.com>