### PR TITLE
[KNI][CARRY] log: noderesourcetopology: per-flow additional log

### DIFF
--- a/pkg/util/log/schedverbose.go
+++ b/pkg/util/log/schedverbose.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"k8s.io/klog/v2"
+)
+
+const (
+	// ObjectSchedVerboseAnnotation informs the scheduler that verbose logs,
+	// if available, should be emitted when processing this pod
+	ObjectSchedVerboseAnnotation = "experimental-verbose.scheduling.sigs.k8s.io"
+)
+
+var (
+	// UpgradedLogLevel is the level we upgrade the verbosiness level if
+	// the given object overrides the priority using the annotation.
+	// We initialize with level which should be enabled most of the time,
+	// but which is still possible to silence.
+	// Client code can still override if needed
+	UpgradedLogLevel klog.Level = 2
+)
+
+// KMetadata is a subset of the kubernetes k8s.io/apimachinery/pkg/apis/meta/v1.Object interface
+// this interface may expand in the future, but will always be a subset of the
+// kubernetes k8s.io/apimachinery/pkg/apis/meta/v1.Object interface
+type KMetadata interface {
+	klog.KMetadata
+	GetAnnotations() map[string]string
+}
+
+// V reports whether verbosity at the call site is at least the requested level,
+// or if the given pod opted in for verbose logging having added the annotation.
+// In the latter case, the verbosiness is transparently bumped to UpgradedLogLevel.
+func V(level klog.Level, obj KMetadata) klog.Verbose {
+	if obj == nil {
+		return klog.V(level)
+	}
+	anns := obj.GetAnnotations()
+	if anns == nil {
+		return klog.V(level)
+	}
+	if _, ok := anns[ObjectSchedVerboseAnnotation]; !ok {
+		return klog.V(level)
+	}
+	return klog.V(UpgradedLogLevel)
+}

--- a/pkg/util/log/schedverbose_test.go
+++ b/pkg/util/log/schedverbose_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+type fakeObject map[string]string
+
+func (fo fakeObject) GetName() string {
+	return "" // unused by the code being exercised
+}
+
+func (fo fakeObject) GetNamespace() string {
+	return "" // unused by the code being exercised
+}
+
+func (fo fakeObject) GetAnnotations() map[string]string {
+	return fo
+}
+
+func TestV(t *testing.T) {
+	type testCase struct {
+		name        string
+		flagValue   int
+		paramValue  int
+		annotations map[string]string
+		expected    bool
+	}
+
+	testCases := []testCase{
+		// sanity checks
+		{
+			name:       "nil object, too verbose",
+			flagValue:  1,
+			paramValue: 5,
+			expected:   false,
+		},
+		{
+			name:       "nil object, matches level",
+			flagValue:  2,
+			paramValue: 2,
+			expected:   true,
+		},
+		{
+			name:       "nil object, verbose enough",
+			flagValue:  3,
+			paramValue: 2,
+			expected:   true,
+		},
+		{
+			name:        "empty annotations, too verbose",
+			flagValue:   1,
+			paramValue:  5,
+			annotations: map[string]string{},
+			expected:    false,
+		},
+		{
+			name:        "empty annotations, matches level",
+			flagValue:   2,
+			paramValue:  2,
+			annotations: map[string]string{},
+			expected:    true,
+		},
+		{
+			name:        "empty annotations, verbose enough",
+			flagValue:   3,
+			paramValue:  2,
+			annotations: map[string]string{},
+			expected:    true,
+		},
+		{
+			name:       "unrelated annotations, too verbose",
+			flagValue:  1,
+			paramValue: 5,
+			annotations: map[string]string{
+				"foo":         "",
+				"sigs.k8s.io": "awesome",
+			},
+			expected: false,
+		},
+		{
+			name:       "unrelated annotations, matches level",
+			flagValue:  2,
+			paramValue: 2,
+			annotations: map[string]string{
+				"foo":         "",
+				"sigs.k8s.io": "awesome",
+			},
+			expected: true,
+		},
+		{
+			name:       "unrelated annotations, verbose enough",
+			flagValue:  3,
+			paramValue: 2,
+			annotations: map[string]string{
+				"foo":         "",
+				"sigs.k8s.io": "awesome",
+			},
+			expected: true,
+		},
+		// this demonstrates we can still silence logs
+		{
+			name:       "magic annotations, flag lower than UpgradedLogLevel",
+			flagValue:  1,
+			paramValue: 5,
+			annotations: map[string]string{
+				"foo":                        "",
+				"sigs.k8s.io":                "awesome",
+				ObjectSchedVerboseAnnotation: "",
+			},
+			expected: false,
+		},
+		// if the global -v setting matches our defaults, we emit the log
+		{
+			name:       "magic annotations, matching level",
+			flagValue:  int(UpgradedLogLevel),
+			paramValue: 5,
+			annotations: map[string]string{
+				"foo":                        "",
+				"sigs.k8s.io":                "awesome",
+				ObjectSchedVerboseAnnotation: "",
+			},
+			expected: true,
+		},
+		// overriding the global value because the object opted in
+		{
+			name:       "magic annotations, overriding verbose",
+			flagValue:  3,
+			paramValue: 5,
+			annotations: map[string]string{
+				"foo":                        "",
+				"sigs.k8s.io":                "awesome",
+				ObjectSchedVerboseAnnotation: "",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := &flag.FlagSet{}
+			klog.InitFlags(flags)
+			flags.Parse([]string{"-v", fmt.Sprintf("%d", tc.flagValue)})
+
+			res := V(klog.Level(tc.paramValue), fakeObject(tc.annotations))
+			if res.Enabled() != tc.expected {
+				t.Errorf("flag=%d param=%d annotations=%v expected=%t got=%t", tc.flagValue, tc.paramValue, tc.annotations, tc.expected, res.Enabled())
+			}
+		})
+	}
+}


### PR DESCRIPTION
All the following applies first and foremost to the
NodeTopologyMatch plugin, but can be easily generalized.

Troubleshooting the behaviour of the components requires almost
always increasing the log level to peek into the flow.
This is due by the fact that, by default, components want to run
with concise logging to avoid log churn and spam.

But increasing the log level very often requires a configuration
change and a component reboot, which is nontrivial to do.
More than that, restarting requires changing the cluster state,
which can make torubleshooting harder, or just longer, while we
reproduce the state.

More than that, the log level is a global, or in the best case
scenario a per-module setting. On the other hand, we are often
interested in the behaviour of a specific flow, possibly across
components, rather than the behaviour of some components.

Increasing the log level then creates unnecessary and uninteresting
logs, which can actually make harder to track the flow.

It would thus be nice to have the option to dynamically enable
detailed logging per-flow across components, avoiding component restart.

I'm not aware of loggers package, including klog, implementing this
feature, but we can have a pretty close approximation with this PR.

We add a new annotation: pods can opt-in including this annotation
in the new behaviour. This allows extra verbosity only on selected
cases (pods).
We add utility function to tune the verbosiness of the logs with
the aforementioned annotation, overriding the default verbosiness level.

IOW, log messages can be emitted if *either*
- the component (/module) verbosity is high enough
OR
- a pod opts in adding the special annotation.

Finally, we consume this new feature in the NodeTopologyMatch plugin,
to both help troubleshooting and to demonstrate its usage.

CAVEATs:
- the feature cannot be turned off (it should probably deserve a global
  disable flag?)
- potentially malicious actors can trigger extra logging adding
  unnecessary annotations.
  - but these actors need to be able to send pods to the scheduler,
    so they have already means to overload the component and/or cause
    extra logging. Not sure this is a practical concern, highligthing
    for full transparency.

Signed-off-by: Francesco Romani <fromani@redhat.com>