### PR TITLE
[KNI] add downstream owners/aliases

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    reviewers:
+      - performance-reviewers
+    approvers:
+      - performance-approvers

--- a/DOWNSTREAM_OWNERS_ALIASES
+++ b/DOWNSTREAM_OWNERS_ALIASES
@@ -1,0 +1,17 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  performance-reviewers:
+    - MarSik
+    - fromanirh
+    - cynepco3hahue
+    - yanirq
+    - Tal-or
+    - marioferh
+    - jlojosnegros
+  performance-approvers:
+    - MarSik
+    - fromanirh
+    - cynepco3hahue
+    - yanirq
+    - Tal-or


### PR DESCRIPTION
Once this is merged, we can revert the OWNERS* to
their u/s counterparts to restore full source tree
compatibility.

Signed-off-by: Francesco Romani <fromani@redhat.com>