### PR TITLE
[KNI] prefer podman for KNI-specific makefile

### DIFF
--- a/Makefile.kni
+++ b/Makefile.kni
@@ -54,7 +54,7 @@ build-noderesourcetopology-plugin.amd64: autogen
 
 .PHONY: local-noderesourcetopology-image
 local-noderesourcetopology-image: clean
-	docker build -f ./build/noderesourcetopology-plugin/Dockerfile --build-arg ARCH="amd64" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(LOCAL_REGISTRY)/$(LOCAL_IMAGE) .
+	podman build -f ./build/noderesourcetopology-plugin/Dockerfile --build-arg ARCH="amd64" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(LOCAL_REGISTRY)/$(LOCAL_IMAGE) .
 
 .PHONY: update-vendor
 update-vendor:


### PR DESCRIPTION
Docker is not recommended anymore for KNI-specific flows.

Signed-off-by: Francesco Romani <fromani@redhat.com>