### PR TITLE
WIP: [KNI] introduce the KNIDebug plugin

### DIFF
--- a/cmd/noderesourcetopology-plugin/main.go
+++ b/cmd/noderesourcetopology-plugin/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 
+	"sigs.k8s.io/scheduler-plugins/pkg-kni/knidebug"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology"
 	// Ensure scheme package is initialized.
 	_ "sigs.k8s.io/scheduler-plugins/pkg/apis/config/scheme"
@@ -37,6 +38,7 @@ func main() {
 	// used by various kinds of workloads.
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(noderesourcetopology.Name, noderesourcetopology.New),
+		app.WithPlugin(knidebug.Name, knidebug.New),
 	)
 
 	// TODO: once we switch everything over to Cobra commands, we can go back to calling

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/scheduler-plugins
 go 1.17
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/google/go-cmp v0.5.5
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.12
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/pkg-kni/knidebug/plugin.go
+++ b/pkg-kni/knidebug/plugin.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knidebug
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dustin/go-humanize"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	topologyapi "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology"
+)
+
+type KNIDebug struct{}
+
+var _ framework.FilterPlugin = &KNIDebug{}
+
+const (
+	// Name is the name of the plugin used in the plugin registry and configurations.
+	Name = "KNIDebug"
+)
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (kd *KNIDebug) Name() string {
+	return Name
+}
+
+// New initializes a new plugin and returns it.
+func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+	klog.V(6).InfoS("Creating new KNIDebug plugin")
+	return &KNIDebug{}, nil
+}
+
+// EventsToRegister returns the possible events that may make a Pod
+// failed by this plugin schedulable.
+// NOTE: if in-place-update (KEP 1287) gets implemented, then PodUpdate event
+// should be registered for this plugin since a Pod update may free up resources
+// that make other Pods schedulable.
+// TODO: keep in sync with noderesourcetoplogy.TopologyMatch
+func (kd *KNIDebug) EventsToRegister() []framework.ClusterEvent {
+	// To register a custom event, follow the naming convention at:
+	// https://git.k8s.io/kubernetes/pkg/scheduler/eventhandlers.go#L403-L410
+	nrtGVK := fmt.Sprintf("noderesourcetopologies.v1alpha1.%v", topologyapi.GroupName)
+	return []framework.ClusterEvent{
+		{Resource: framework.Pod, ActionType: framework.Delete},
+		{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeAllocatable},
+		{Resource: framework.GVK(nrtGVK), ActionType: framework.Add | framework.Update},
+	}
+}
+
+func (kd *KNIDebug) Filter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+	if nodeInfo.Node() == nil {
+		return framework.NewStatus(framework.Error, "node not found")
+	}
+
+	klog.V(6).InfoS("node available",
+		"node", nodeInfo.Node().Name,
+		"cpu", (nodeInfo.Allocatable.MilliCPU - nodeInfo.Requested.MilliCPU),
+		"memory", humanize.IBytes(uint64(nodeInfo.Allocatable.Memory-nodeInfo.Requested.Memory)),
+	)
+
+	return nil
+}


### PR DESCRIPTION
The KNIDebug is meant to be a passthrough plugin (which will
fail only in the most catastrophic of cases) which we can use
to inject extra logs u/s is not willing or interesting to accept.

Using the KNIDebug plugin, we can choose between the tradeoff
of changing the u/s code (which increases the maintainership
costs) at the cost of limiting ourselves in the logs we can add:
some logs can only meaningfully by added in the private function
of some plugins.

Signed-off-by: Francesco Romani <fromani@redhat.com>
