### PR TITLE
go1.18 compiler updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18.1
 
       - name: Run integration test
         run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v2
         id: go
         with:
-          go-version: 1.17
+          go-version: 1.18.1
 
       - name: Set release version env var
         run: |

--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.17.6
+FROM golang:1.18
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.17.2
+ENV GOVERSION=1.18.1
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG ARCH
-FROM golang:1.17.6
+FROM golang:1.18
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .


### PR DESCRIPTION
1. Dockerfile updates
2.  Update github CI workflows to go 1.18.1

Splitting from https://github.com/openshift-kni/scheduler-plugins/pull/36 based on the input received here https://github.com/openshift-kni/scheduler-plugins/pull/36#issuecomment-1131954702.