### PR TITLE
go1.18: Using go install as go get is deprecated in go 1.18

### DIFF
--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -26,9 +26,9 @@ RUN mkdir -p $HOME && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz && \
     # get required golang tools and OC client
-    go get github.com/onsi/ginkgo/ginkgo && \
-    go get golang.org/x/lint/golint && \
-    go get github.com/mattn/goveralls && \
+    go install github.com/onsi/ginkgo/ginkgo@latest && \
+    go install golang.org/x/lint/golint@latest && \
+    go install github.com/mattn/goveralls@latest && \
     go clean -cache -modcache && \
     rm -rf ${GOPATH}/src/* && \
     rm -rf ${GOPATH}/pkg/* && \


### PR DESCRIPTION
Installation of executables with go get is deprecated
in go1.18 (xref:https://go.dev/doc/go-get-install-deprecation)
so we use go install instead.