### PR TITLE
[KNI] introduce the KNIDebug plugin

### DIFF
--- a/Makefile.kni
+++ b/Makefile.kni
@@ -12,25 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARCHS = amd64 arm64
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
 BUILDENVVAR=CGO_ENABLED=0
 
-LOCAL_REGISTRY?=localhost:5000/scheduler-plugins
-LOCAL_IMAGE?=kube-scheduler:latest
-LOCAL_CONTROLLER_IMAGE?=controller:latest
+CONTAINER_REGISTRY?="quay.io/openshift-kni"
+CONTAINER_IMAGE?="scheduler-plugins"
 
-# RELEASE_REGISTRY is the container registry to push
-# into. The default is to push to the staging
-# registry, not production(k8s.gcr.io).
-RELEASE_REGISTRY?=gcr.io/k8s-staging-scheduler-plugins
-RELEASE_VERSION?=v$(shell date +%Y%m%d)-$(shell git describe --tags --match "v*")
-RELEASE_IMAGE:=kube-scheduler:$(RELEASE_VERSION)
-RELEASE_CONTROLLER_IMAGE:=controller:$(RELEASE_VERSION)
+RELEASE_SEQUENTIAL?=01
+RELEASE_VERSION?=devel-v0.0.$(shell date +%Y%m%d)$(RELEASE_SEQUENTIAL)
 
 # VERSION is the scheduler's version
 #
-# The RELEASE_VERSION variable can have one of two formats:
+# The RELEASE_VERSION variable can have one of the following formats:
 # v20201009-v0.18.800-46-g939c1c0 - automated build for a commit(not a tag) and also a local build
 # v20200521-v0.18.800             - automated build for a tag
 VERSION=$(shell echo $(RELEASE_VERSION) | awk -F - '{print $$2}')
@@ -40,6 +33,9 @@ all: build
 
 .PHONY: build
 build: build-noderesourcetopology-plugin
+
+.PHONY: image
+image: build-noderesourcetopology-image
 
 .PHONY: build.amd64
 build.amd64: build-scheduler.amd64 build-noderesourcetopology-plugin.amd64
@@ -53,8 +49,8 @@ build-noderesourcetopology-plugin.amd64: update-vendor
 	$(COMMONENVVAR) $(BUILDENVVAR) GOARCH=amd64 go build -ldflags '-X k8s.io/component-base/version.gitVersion=$(VERSION) -w' -o bin/noderesourcetopology-plugin cmd/noderesourcetopology-plugin/main.go
 
 .PHONY: local-noderesourcetopology-image
-local-noderesourcetopology-image: clean
-	podman build -f ./build/noderesourcetopology-plugin/Dockerfile --build-arg ARCH="amd64" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(LOCAL_REGISTRY)/$(LOCAL_IMAGE) .
+build-noderesourcetopology-image: clean
+	podman build -f ./build/noderesourcetopology-plugin/Dockerfile --build-arg ARCH="amd64" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(CONTAINER_REGISTRY)/$(CONTAINER_IMAGE):$(VERSION) .
 
 .PHONY: update-vendor
 update-vendor:

--- a/cmd/noderesourcetopology-plugin/main.go
+++ b/cmd/noderesourcetopology-plugin/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 
+	"sigs.k8s.io/scheduler-plugins/pkg-kni/knidebug"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology"
 	// Ensure scheme package is initialized.
 	_ "sigs.k8s.io/scheduler-plugins/apis/config/scheme"
@@ -37,6 +38,7 @@ func main() {
 	// used by various kinds of workloads.
 	command := app.NewSchedulerCommand(
 		app.WithPlugin(noderesourcetopology.Name, noderesourcetopology.New),
+		app.WithPlugin(knidebug.Name, knidebug.New),
 	)
 
 	// TODO: once we switch everything over to Cobra commands, we can go back to calling

--- a/hack-kni/unit-test-quick.sh
+++ b/hack-kni/unit-test-quick.sh
@@ -27,4 +27,5 @@ source "${SCRIPT_ROOT}/hack/lib/init.sh"
 # TODO: make args customizable.
 go test -mod=vendor \
   sigs.k8s.io/scheduler-plugins/cmd/noderesourcetopology-plugin/... \
-  sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/...
+  sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/... \
+  sigs.k8s.io/scheduler-plugins/pkg-kni/...

--- a/pkg-kni/knidebug/knidebug.go
+++ b/pkg-kni/knidebug/knidebug.go
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package knidebug
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/dustin/go-humanize"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	resourcehelper "k8s.io/kubernetes/pkg/api/v1/resource"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type KNIDebug struct{}
+
+var _ framework.FilterPlugin = &KNIDebug{}
+
+const (
+	// Name is the name of the plugin used in the plugin registry and configurations.
+	Name     string     = "KNIDebug"
+	LogLevel klog.Level = 6
+)
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (kd *KNIDebug) Name() string {
+	return Name
+}
+
+// New initializes a new plugin and returns it.
+func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+	klog.V(6).InfoS("Creating new KNIDebug plugin")
+	return &KNIDebug{}, nil
+}
+
+func (kd *KNIDebug) EventsToRegister() []framework.ClusterEvent {
+	// this can actually be empty - this plugin never fails, but we keep the same
+	// (simple and safe) events noderesourcesfit registered
+	return []framework.ClusterEvent{
+		{Resource: framework.Pod, ActionType: framework.Delete},
+		{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeAllocatable},
+	}
+}
+
+func (kd *KNIDebug) Filter(ctx context.Context, cycleState *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+	node := nodeInfo.Node()
+	if node == nil {
+		// should never happen
+		return framework.NewStatus(framework.Error, "node not found")
+	}
+
+	logKey := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+	// note the fit.go plugin computes this in the prefilter stage. Does this make any practical difference in our context?
+	req := computePodResourceRequest(pod)
+	checkRequest(LogLevel, logKey, req, nodeInfo)
+	return nil // must never fail
+}
+
+func frameworkResourceToLoggable(logKey string, req *framework.Resource) []interface{} {
+	items := []interface{}{
+		"logKey", logKey,
+		"cpu", humanCPU(req.MilliCPU),
+		"memory", humanMemory(req.Memory),
+	}
+
+	resNames := []string{}
+	for resName := range req.ScalarResources {
+		resNames = append(resNames, string(resName))
+	}
+	sort.Strings(resNames)
+
+	for _, resName := range resNames {
+		quan := req.ScalarResources[corev1.ResourceName(resName)]
+		if resourcehelper.IsHugePageResourceName(corev1.ResourceName(resName)) {
+			items = append(items, resName, humanMemory(quan))
+		} else {
+			items = append(items, resName, strconv.FormatInt(quan, 10))
+		}
+	}
+	return items
+}
+
+type humanMemory int64
+
+func (hi humanMemory) String() string {
+	return fmt.Sprintf("%d (%s)", hi, humanize.IBytes(uint64(hi)))
+}
+
+type humanCPU int64
+
+func (hc humanCPU) String() string {
+	return fmt.Sprintf("%d (%d)", hc, hc/1000)
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// logic taken from fit.go, changing the return value to use a plain *framework.Resource
+// https://github.com/kubernetes/kubernetes/blob/v1.24.0/pkg/scheduler/framework/plugins/noderesources/fit.go#L133-L175
+
+// computePodResourceRequest returns a framework.Resource that covers the largest
+// width in each resource dimension. Because init-containers run sequentially, we collect
+// the max in each dimension iteratively. In contrast, we sum the resource vectors for
+// regular containers since they run simultaneously.
+//
+// The resources defined for Overhead should be added to the calculated Resource request sum
+//
+// Example:
+//
+// Pod:
+//   InitContainers
+//     IC1:
+//       CPU: 2
+//       Memory: 1G
+//     IC2:
+//       CPU: 2
+//       Memory: 3G
+//   Containers
+//     C1:
+//       CPU: 2
+//       Memory: 1G
+//     C2:
+//       CPU: 1
+//       Memory: 1G
+//
+// Result: CPU: 3, Memory: 3G
+func computePodResourceRequest(pod *corev1.Pod) *framework.Resource {
+	result := &framework.Resource{}
+	for _, container := range pod.Spec.Containers {
+		result.Add(container.Resources.Requests)
+	}
+
+	// take max_resource(sum_pod, any_init_container)
+	for _, container := range pod.Spec.InitContainers {
+		result.SetMaxResource(container.Resources.Requests)
+	}
+
+	if pod.Spec.Overhead != nil {
+		result.Add(pod.Spec.Overhead)
+	}
+	return result
+}
+
+// see again fit.go for the skeleton code. Here we intentionally only log
+func checkRequest(logLevel klog.Level, logKey string, podRequest *framework.Resource, nodeInfo *framework.NodeInfo) {
+	if podRequest.MilliCPU == 0 && podRequest.Memory == 0 && podRequest.EphemeralStorage == 0 && len(podRequest.ScalarResources) == 0 {
+		klog.V(logLevel).InfoS("target resource requests none", "logKey", logKey)
+		return
+	}
+	klog.V(logLevel).InfoS("target resource requests", frameworkResourceToLoggable(logKey, podRequest)...)
+
+	nodeName := nodeInfo.Node().Name // shortcut
+
+	violations := 0
+	if availCPU := (nodeInfo.Allocatable.MilliCPU - nodeInfo.Requested.MilliCPU); podRequest.MilliCPU > availCPU {
+		klog.V(logLevel).InfoS("insufficient node resources", "logKey", logKey, "node", nodeName, "resource", "CPU", "request", humanCPU(podRequest.MilliCPU), "available", humanCPU(availCPU))
+		violations++
+	}
+	if availMemory := (nodeInfo.Allocatable.Memory - nodeInfo.Requested.Memory); podRequest.Memory > availMemory {
+		klog.V(logLevel).InfoS("insufficient node resources", "logKey", logKey, "node", nodeName, "resource", "memory", "request", humanMemory(podRequest.Memory), "available", humanMemory(availMemory))
+		violations++
+	}
+	for rName, rQuant := range podRequest.ScalarResources {
+		if availQuant := (nodeInfo.Allocatable.ScalarResources[rName] - nodeInfo.Requested.ScalarResources[rName]); rQuant > availQuant {
+			klog.V(logLevel).InfoS("insufficient node resources", "logKey", logKey, "node", nodeName, "resource", rName, "request", rQuant, "available", availQuant)
+			violations++
+		}
+	}
+
+	if violations > 0 {
+		return
+	}
+	klog.V(logLevel).InfoS("enough node resources", "logKey", logKey, "node", nodeName)
+}

--- a/pkg-kni/knidebug/knidebug_test.go
+++ b/pkg-kni/knidebug/knidebug_test.go
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package knidebug
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func TestFrameworkResourceToLoggable(t *testing.T) {
+	tests := []struct {
+		name      string
+		logKey    string
+		resources *framework.Resource
+		expected  string
+	}{
+		{
+			name:      "empty",
+			logKey:    "",
+			resources: &framework.Resource{},
+			expected:  ` logKey="" cpu="0 (0)" memory="0 (0 B)"`,
+		},
+		{
+			name:      "only logKey",
+			logKey:    "TEST1",
+			resources: &framework.Resource{},
+			expected:  ` logKey="TEST1" cpu="0 (0)" memory="0 (0 B)"`,
+		},
+		{
+			name:   "only CPUs",
+			logKey: "TEST1",
+			resources: &framework.Resource{
+				MilliCPU: 16000,
+			},
+			expected: ` logKey="TEST1" cpu="16000 (16)" memory="0 (0 B)"`,
+		},
+		{
+			name:   "only Memory",
+			logKey: "TEST2",
+			resources: &framework.Resource{
+				Memory: 16 * 1024 * 1024 * 1024,
+			},
+			expected: ` logKey="TEST2" cpu="0 (0)" memory="17179869184 (16 GiB)"`,
+		},
+		{
+			name:   "CPUs and Memory, no logKey",
+			logKey: "",
+			resources: &framework.Resource{
+				MilliCPU: 24000,
+				Memory:   16 * 1024 * 1024 * 1024,
+			},
+			expected: ` logKey="" cpu="24000 (24)" memory="17179869184 (16 GiB)"`,
+		},
+		{
+			name:   "CPUs and Memory",
+			logKey: "TEST3",
+			resources: &framework.Resource{
+				MilliCPU: 24000,
+				Memory:   16 * 1024 * 1024 * 1024,
+			},
+			expected: ` logKey="TEST3" cpu="24000 (24)" memory="17179869184 (16 GiB)"`,
+		},
+		{
+			name:   "CPUs, Memory, hugepages-2Mi",
+			logKey: "TEST4",
+			resources: &framework.Resource{
+				MilliCPU: 24000,
+				Memory:   16 * 1024 * 1024 * 1024,
+				ScalarResources: map[corev1.ResourceName]int64{
+					corev1.ResourceName("hugepages-2Mi"): 1 * 1024 * 1024 * 1024,
+				},
+			},
+			expected: ` logKey="TEST4" cpu="24000 (24)" memory="17179869184 (16 GiB)" hugepages-2Mi="1073741824 (1.0 GiB)"`,
+		},
+		{
+			name:   "CPUs, Memory, hugepages-2Mi, hugepages-1Gi",
+			logKey: "TEST4",
+			resources: &framework.Resource{
+				MilliCPU: 24000,
+				Memory:   16 * 1024 * 1024 * 1024,
+				ScalarResources: map[corev1.ResourceName]int64{
+					corev1.ResourceName("hugepages-2Mi"): 1 * 1024 * 1024 * 1024,
+					corev1.ResourceName("hugepages-1Gi"): 2 * 1024 * 1024 * 1024,
+				},
+			},
+			expected: ` logKey="TEST4" cpu="24000 (24)" memory="17179869184 (16 GiB)" hugepages-1Gi="2147483648 (2.0 GiB)" hugepages-2Mi="1073741824 (1.0 GiB)"`,
+		},
+		{
+			name:   "CPUs, Memory, hugepages-2Mi, devices",
+			logKey: "TEST4",
+			resources: &framework.Resource{
+				MilliCPU: 24000,
+				Memory:   16 * 1024 * 1024 * 1024,
+				ScalarResources: map[corev1.ResourceName]int64{
+					corev1.ResourceName("hugepages-2Mi"):         1 * 1024 * 1024 * 1024,
+					corev1.ResourceName("example.com/netdevice"): 16,
+					corev1.ResourceName("awesome.net/gpu"):       4,
+				},
+			},
+			expected: ` logKey="TEST4" cpu="24000 (24)" memory="17179869184 (16 GiB)" awesome.net/gpu="4" example.com/netdevice="16" hugepages-2Mi="1073741824 (1.0 GiB)"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			keysAndValues := frameworkResourceToLoggable(tt.logKey, tt.resources)
+			kvListFormat(&buf, keysAndValues...)
+			got := buf.String()
+			if got != tt.expected {
+				t.Errorf("got=[%s] expected=[%s]", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCheckRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		logKey     string
+		podRequest *framework.Resource
+		nodeInfo   *framework.NodeInfo
+		expected   []string
+	}{
+		{
+			name:       "empty",
+			logKey:     "",
+			podRequest: &framework.Resource{},
+			nodeInfo: newNodeInfo(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-0",
+				},
+			}),
+			expected: []string{
+				`target resource requests none`,
+			},
+		},
+		{
+			name:   "cpu",
+			logKey: "",
+			podRequest: &framework.Resource{
+				MilliCPU: 2000,
+			},
+			nodeInfo: newNodeInfo(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-0",
+				},
+			}),
+			expected: []string{
+				`insufficient node resources" logKey="" node="node-0" resource="CPU"`,
+			},
+		},
+		{
+			name:   "memory",
+			logKey: "",
+			podRequest: &framework.Resource{
+				Memory: 8 * 1024 * 1024 * 1024,
+			},
+			nodeInfo: newNodeInfo(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-0",
+				},
+			}),
+			expected: []string{
+				`insufficient node resources" logKey="" node="node-0" resource="memory"`,
+			},
+		},
+		{
+			name:   "devices",
+			logKey: "",
+			podRequest: &framework.Resource{
+				ScalarResources: map[corev1.ResourceName]int64{
+					corev1.ResourceName("example.com/device"): 2,
+				},
+			},
+			nodeInfo: newNodeInfo(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-0",
+				},
+			}),
+			expected: []string{
+				`insufficient node resources" logKey="" node="node-0" resource="example.com/device"`,
+			},
+		},
+		{
+			name:   "cpu and memory",
+			logKey: "",
+			podRequest: &framework.Resource{
+				MilliCPU: 4000,
+				Memory:   16 * 1024 * 1024 * 1024,
+			},
+			nodeInfo: newNodeInfo(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-0",
+				},
+			}),
+			expected: []string{
+				`insufficient node resources" logKey="" node="node-0" resource="memory"`,
+				`insufficient node resources" logKey="" node="node-0" resource="CPU"`,
+			},
+		},
+		{
+			name:   "memory and devices",
+			logKey: "",
+			podRequest: &framework.Resource{
+				Memory: 16 * 1024 * 1024 * 1024,
+				ScalarResources: map[corev1.ResourceName]int64{
+					corev1.ResourceName("example.com/device"): 2,
+				},
+			},
+			nodeInfo: newNodeInfo(&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-0",
+				},
+			}),
+			expected: []string{
+				`insufficient node resources" logKey="" node="node-0" resource="example.com/device"`,
+				`insufficient node resources" logKey="" node="node-0" resource="memory"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := runWithStderr(os.Stderr, func() error {
+				checkRequest(0, tt.logKey, tt.podRequest, tt.nodeInfo)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("%v", err)
+			}
+			for _, exp := range tt.expected {
+				if !strings.Contains(got, exp) {
+					t.Errorf("got=[%s] not found in expected=[%s]", got, exp)
+				}
+			}
+		})
+	}
+
+}
+func newNodeInfo(node *corev1.Node) *framework.NodeInfo {
+	ninfo := framework.NewNodeInfo()
+	ninfo.SetNode(node)
+	return ninfo
+}
+
+func runWithStderr(oldStderr *os.File, fn func() error) (string, error) {
+	defer func() {
+		// don't hurt to do it twice/anyway
+		os.Stderr = oldStderr
+	}()
+	f, err := os.CreateTemp("", "stderrtest")
+	if err != nil {
+		return "", err
+	}
+	tmpName := f.Name()
+	defer os.Remove(tmpName)
+
+	os.Stderr = f
+	err = fn()
+	os.Stderr = oldStderr // restore ASAP
+
+	if err != nil {
+		return "", err
+	}
+	err = f.Close()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(tmpName)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// taken from klog
+
+const missingValue = "(MISSING)"
+
+func kvListFormat(b *bytes.Buffer, keysAndValues ...interface{}) {
+	for i := 0; i < len(keysAndValues); i += 2 {
+		var v interface{}
+		k := keysAndValues[i]
+		if i+1 < len(keysAndValues) {
+			v = keysAndValues[i+1]
+		} else {
+			v = missingValue
+		}
+		b.WriteByte(' ')
+
+		switch v.(type) {
+		case string, error:
+			b.WriteString(fmt.Sprintf("%s=%q", k, v))
+		case []byte:
+			b.WriteString(fmt.Sprintf("%s=%+q", k, v))
+		default:
+			if _, ok := v.(fmt.Stringer); ok {
+				b.WriteString(fmt.Sprintf("%s=%q", k, v))
+			} else {
+				b.WriteString(fmt.Sprintf("%s=%+v", k, v))
+			}
+		}
+	}
+}


### PR DESCRIPTION
The KNIDebug is meant to be a passthrough plugin (which will fail only in the most catastrophic of cases) which we can use
to inject extra logs u/s is not willing or interesting to accept.

Using the KNIDebug plugin, we can choose between the tradeoff of changing the u/s code (which increases the maintainership
costs) at the cost of limiting ourselves in the logs we can add: some logs can only meaningfully by added in the private function
of some plugins.

Signed-off-by: Francesco Romani <fromani@redhat.com>
