### PR TITLE
[KNI] move infrastructure to golang 1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.1
+          go-version: 1.19.5
 
       - name: Run integration test
         run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v2
         id: go
         with:
-          go-version: 1.18.1
+          go-version: 1.19.5
 
       - name: Set release version env var
         run: |

--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.18.1
+ENV GOVERSION=1.19.5
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}


### PR DESCRIPTION
Before to move the requirement to 1.19, we need to make sure the tooling is updated to 1.19. On the bright side, this is a trivial toolchain bump

Signed-off-by: Francesco Romani <fromani@redhat.com>
