### PR TITLE
[KNI] update package requirement to 1.19 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/scheduler-plugins
 
-go 1.18
+go 1.19
 
 require (
 	github.com/diktyo-io/appgroup-api v0.0.9-alpha


### PR DESCRIPTION
Now that we have the infra in place shipping the 1.19
toolchain, we can bump the package requirements to 1.19,
completing the update. Depends on #70 

Signed-off-by: Francesco Romani <fromani@redhat.com>