### PR TITLE
[KNI] enable CI on LTS branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release-4.12 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release-4.12 ]
 
 jobs:
   commit-check:


### PR DESCRIPTION
So far, only `relase-4.12` is LTS
