### PR TITLE
[KNI] enable CI on LTS branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release-4.12 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release-4.12 ]
 
 jobs:
   commit-check:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,24 +7,6 @@ on:
     branches: [ master, release-4.12 ]
 
 jobs:
-  commit-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Get branch name (pull request)
-        shell: bash
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-
-      - name: Debug
-        run: echo ${{ env.BRANCH_NAME }}
-
-      - name: Verify commits
-        run: TRIGGER_BRANCH=${{ env.BRANCH_NAME }} ./hack-kni/verify-commits.sh
-
   integration-test:
     runs-on: ubuntu-latest
     env:

--- a/hack-kni/integration-test-quick.sh
+++ b/hack-kni/integration-test-quick.sh
@@ -34,7 +34,9 @@ runTests() {
   kube::log::status "Running integration test cases"
   # TODO: make args customizable.
   go test -timeout=40m -mod=vendor -v \
+	  test/integration/noderesourcetopology_cache_test.go \
 	  test/integration/noderesourcetopology_test.go \
+	  test/integration/nrtutils.go \
 	  test/integration/utils.go \
 	  test/integration/main_test.go
 }


### PR DESCRIPTION
So far, only `relase-4.12` is LTS
