### PR TITLE
nrt: add optional kni-specific informer

### DIFF
--- a/cmd/noderesourcetopology-plugin/main.go
+++ b/cmd/noderesourcetopology-plugin/main.go
@@ -34,6 +34,8 @@ import (
 	// Ensure scheme package is initialized.
 	_ "sigs.k8s.io/scheduler-plugins/apis/config/scheme"
 
+	kniinformer "sigs.k8s.io/scheduler-plugins/pkg-kni/podinformer"
+
 	"github.com/k8stopologyawareschedwg/podfingerprint"
 )
 
@@ -59,6 +61,8 @@ func setupPFPStatusDump() {
 
 func main() {
 	rand.Seed(time.Now().UnixNano())
+
+	kniinformer.Setup()
 
 	// Register custom plugins to the scheduler framework.
 	// Later they can consist of scheduler profile(s) and hence

--- a/pkg-kni/podinformer/podinformer.go
+++ b/pkg-kni/podinformer/podinformer.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podinformer
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	podlisterv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	k8scache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+const (
+	nrtInformerEnvVar string = "NRT_ENABLE_INFORMER"
+)
+
+var (
+	enabled bool
+)
+
+func IsEnabled() bool {
+	return enabled
+}
+
+func Setup() {
+	hasNRTInf, ok := os.LookupEnv(nrtInformerEnvVar)
+	if !ok || hasNRTInf == "" {
+		klog.InfoS("NRT specific informer disabled", "variableFound", ok, "valueGiven", hasNRTInf != "")
+		return
+	}
+	val, err := strconv.ParseBool(hasNRTInf)
+	if err != nil {
+		klog.Error(err, "NRT specific informer disabled")
+		return
+	}
+	klog.InfoS("NRT specific informer status", "value", val)
+	enabled = val
+}
+
+func FromHandle(handle framework.Handle) (k8scache.SharedIndexInformer, podlisterv1.PodLister) {
+	if !IsEnabled() {
+		podHandle := handle.SharedInformerFactory().Core().V1().Pods() // shortcut
+		return podHandle.Informer(), podHandle.Lister()
+	}
+
+	podInformer := coreinformers.NewFilteredPodInformer(handle.ClientSet(), metav1.NamespaceAll, 0, cache.Indexers{}, nil)
+	podLister := podlisterv1.NewPodLister(podInformer.GetIndexer())
+
+	klog.V(5).InfoS("Start custom pod informer")
+	ctx := context.Background()
+	go podInformer.Run(ctx.Done())
+
+	klog.V(5).InfoS("Syncing custom pod informer")
+	cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced)
+	klog.V(5).InfoS("Synced custom pod informer")
+
+	return podInformer, podLister
+}
+
+func IsPodRelevantForState(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false // should never happen
+	}
+	if IsEnabled() {
+		return true // consider all pods including ones in terminal phase
+	}
+	return pod.Status.Phase == corev1.PodRunning // we are interested only about nodes which consume resources
+}

--- a/pkg/noderesourcetopology/cache/store.go
+++ b/pkg/noderesourcetopology/cache/store.go
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
 
 	"github.com/k8stopologyawareschedwg/podfingerprint"
+
+	kniinformer "sigs.k8s.io/scheduler-plugins/pkg-kni/podinformer"
 )
 
 // nrtStore maps the NRT data by node name. It is not thread safe and needs to be protected by a lock.
@@ -254,7 +256,7 @@ func makeNodeToPodDataMap(podLister podlisterv1.PodLister, logID string) (map[st
 		return nodeToObjsMap, err
 	}
 	for _, pod := range pods {
-		if pod.Status.Phase != corev1.PodRunning {
+		if !kniinformer.IsPodRelevantForState(pod) {
 			// we are interested only about nodes which consume resources
 			continue
 		}

--- a/pkg/noderesourcetopology/pluginhelpers.go
+++ b/pkg/noderesourcetopology/pluginhelpers.go
@@ -36,6 +36,8 @@ import (
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 	nrtcache "sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/cache"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/stringify"
+
+	kniinformer "sigs.k8s.io/scheduler-plugins/pkg-kni/podinformer"
 )
 
 const (
@@ -66,7 +68,7 @@ func initNodeTopologyInformer(tcfg *apiconfig.NodeResourceTopologyMatchArgs, han
 		return nrtcache.NewPassthrough(nodeTopologyLister), nil
 	}
 
-	podSharedInformer, podLister := nrtcache.InformerFromHandle(handle)
+	podSharedInformer, podLister := kniinformer.FromHandle(handle)
 
 	nrtCache, err := nrtcache.NewOverReserve(tcfg.Cache, nodeTopologyLister, podLister)
 	if err != nil {


### PR DESCRIPTION
The podinformer supplied by the scheduler framework filters out pods in terminal state. Changing this is nontrivial, and we need a fix on older versions.

In order to completely fix the non-running pod desync, we need to either get pods in terminal phase on the scheduler side or to filter out these pods on nodes.
 
 The best option here is adding a separate independent dedicated informer on the scheduler side. This is the more self contained change AND the one which scales better, requiring "just" one additional subscription to the apiserver (vs N=len(workers)).

The extra dedicated informer can be enabled using the environment variable `NRT_ENABLE_INFORMER=<bool>`. If disabled, the code behaves exactly like previously, using the scheduler-framework provided informer.

We still need to pursue options in the context of the scheduler framework to see which improvements we can land in there.
