### PR TITLE
[KNI] Makefile: build: use shared libraries

### DIFF
--- a/Makefile.kni
+++ b/Makefile.kni
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 COMMONENVVAR=GOOS=$(shell uname -s | tr A-Z a-z)
-BUILDENVVAR=CGO_ENABLED=0
+BUILDENVVAR=
 
 CONTAINER_REGISTRY?="quay.io/openshift-kni"
 CONTAINER_IMAGE?="scheduler-plugins"


### PR DESCRIPTION
In some cases we don't really need the fully static compilation and we can depend on system libraries.
