### PR TITLE
[KNI] Dockerfile: drop python2

### DIFF
--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -17,7 +17,6 @@ RUN yum --setopt=install_weak_deps=False -y install \
     gettext \
     which \
     findutils \
-    python2 \
     && yum clean all
 
 RUN mkdir -p $HOME && \


### PR DESCRIPTION
Python2 no longer needed and its presence is causing CI failure in https://github.com/openshift-kni/scheduler-plugins/pull/116. 