### PR TITLE
[KNI][release-4.14][manual] toolchain: golang: bump to 1.20.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.20.7
 
       - name: Run integration test
         run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.19.5
+          go-version: 1.20.7
 
       - name: Set release version env var
         run: |

--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.19.5
+ENV GOVERSION=1.20.7
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}


### PR DESCRIPTION
Bump to golang 1.20

Intentionally not bump `go.mod`: we will inherit from u/s
