### PR TITLE
[KNI][release-4.14][manual] pfpstatus: fix BaseDirectory bug

### DIFF
--- a/pkg-kni/pfpstatus/pfpstatus.go
+++ b/pkg-kni/pfpstatus/pfpstatus.go
@@ -28,10 +28,6 @@ import (
 	"github.com/k8stopologyawareschedwg/podfingerprint"
 )
 
-const (
-	BaseDirectory = "/run/pfpstatus"
-)
-
 type StatusInfo struct {
 	podfingerprint.Status
 	LastWrite time.Time `json:"lastWrite"`
@@ -65,7 +61,7 @@ func RunForever(ctx context.Context, logger logr.Logger, baseDirectory string, u
 				LastWrite: time.Now(),
 				SeqNo:     seqNo,
 			}
-			DumpNodeStatus(BaseDirectory, sti)
+			DumpNodeStatus(baseDirectory, sti)
 		}
 	}
 }


### PR DESCRIPTION
A typo disallowed user setting override of the builtin BaseDirectory. Turns out the builtin default is not needed or used, so remove it.