### PR TITLE
[KNI] nrt: filter: fail if missing data

### DIFF
--- a/pkg-kni/customization/filter.go
+++ b/pkg-kni/customization/filter.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customization
+
+import (
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
+)
+
+func RejectNode(nodeName string, scoreStrategyType apiconfig.ScoringStrategyType, reason string) *framework.Status {
+	if scoreStrategyType == apiconfig.LeastNUMANodes {
+		klog.V(4).InfoS("allowed by scoring strategy", "node", nodeName, "scoreStrategy", scoreStrategyType)
+		return nil
+	}
+	klog.V(2).InfoS(reason, "node", nodeName)
+	return framework.NewStatus(framework.Unschedulable, reason)
+}

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -33,6 +33,8 @@ import (
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/resourcerequests"
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/stringify"
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
+
+	knicustom "sigs.k8s.io/scheduler-plugins/pkg-kni/customization"
 )
 
 // The maximum number of NUMA nodes that Topology Manager allows is 8
@@ -208,7 +210,7 @@ func (tm *TopologyMatch) Filter(ctx context.Context, cycleState *framework.Cycle
 		return framework.NewStatus(framework.Unschedulable, "invalid node topology data")
 	}
 	if nodeTopology == nil {
-		return nil
+		return knicustom.RejectNode(nodeName, tm.scoreStrategyType, "missing topology data")
 	}
 
 	klog.V(5).InfoS("Found NodeResourceTopology", "nodeTopology", klog.KObj(nodeTopology))


### PR DESCRIPTION
Differently from the upstream version, we want to filter out (not allow) nodes which have missing or wrong topology data.

IOW, if a node lacks topology data (or if it's inconsistent), it should be unsuitable to run a pod.