### PR TITLE
[KNI][release-4.14] ghactions: more specific commit check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
         run: |
           TRIGGER_BRANCH=${{ env.SOURCE_BRANCH_NAME }} \
           UPSTREAM_BRANCH=${{ env.TARGET_BRANCH_NAME }} \
+          COMMITS=${{ github.event.pull_request.commits }} \
           ./hack-kni/verify-commits.sh
 
   integration-test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,15 +15,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get branch name (pull request)
+      - name: Get branch names (pull request)
         shell: bash
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+        run: |
+          echo "SOURCE_BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+          echo "TARGET_BRANCH_NAME=$(echo ${GITHUB_BASE_REF} | tr / -)" >> $GITHUB_ENV
 
       - name: Debug
-        run: echo ${{ env.BRANCH_NAME }}
+        run: |
+          echo ${{ env.SOURCE_BRANCH_NAME }}
+          echo ${{ env.TARGET_BRANCH_NAME }}
 
       - name: Verify commits
-        run: TRIGGER_BRANCH=${{ env.BRANCH_NAME }} ./hack-kni/verify-commits.sh
+        run: |
+          TRIGGER_BRANCH=${{ env.SOURCE_BRANCH_NAME }} \
+          UPSTREAM_BRANCH=${{ env.TARGET_BRANCH_NAME }} \
+          ./hack-kni/verify-commits.sh
 
   integration-test:
     runs-on: ubuntu-latest

--- a/hack-kni/verify-commits.sh
+++ b/hack-kni/verify-commits.sh
@@ -17,42 +17,18 @@ if [[ "$TRIGGER_BRANCH" == resync-* ]]; then
   exit 0
 fi
 
-if [[ -z "$UPSTREAM_COMMIT" ]]; then
-	# CI=true is set by prow as a way to detect we are running under the ci
-	if [[ -n "$CI" ]]; then
-		latest_upstream_commit=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/openshift-kni/scheduler-plugins/commits?per_page=1 | jq -r '.[0].sha')
-	else
-		if [[ -z "$UPSTREAM_BRANCH" ]]; then
-			latest_upstream_commit="origin/master"
-		else
-			latest_upstream_commit=$UPSTREAM_BRANCH
-		fi
-
-		if [[ ! $(git branch --list --all "$latest_upstream_commit") ]]; then
-			echo WARN: could not find "$latest_upstream_commit", consider using a different UPSTREAM_BRANCH value
-		fi
-
-	fi
-else
-	latest_upstream_commit="$UPSTREAM_COMMIT"
-	if [[ ! $(git cat-file -t "$UPSTREAM_COMMIT") == "commit" ]]; then
-		echo WARN: "$UPSTREAM_COMMIT" commitish could not be found in repo
-	fi
-fi
-
-commits_diff_count=$(git log --oneline "$latest_upstream_commit"..HEAD | wc -l)
-if [[ $commits_diff_count -eq 0 ]]; then
+if (( $COMMITS <= 0 )); then
 	echo "WARN: no changes detected"
 	exit 0
 fi
 
-echo commits between "$latest_upstream_commit"..HEAD:
+echo "considering ${COMMITS} commits in PR whose head is $TRIGGER_BRANCH (into $UPSTREAM_BRANCH):"
 echo "---"
-git log --oneline --no-merges "$latest_upstream_commit"..HEAD
+git log --oneline --no-merges -n ${COMMITS}
 echo "---"
 
 # list commits
-for commitish in $( git log --oneline --no-merges "$latest_upstream_commit"..HEAD | cut -d' ' -f 1); do
+for commitish in $( git log --oneline --no-merges -n ${COMMITS} | cut -d' ' -f 1); do
   echo "CHECK: $commitish"
   .github/hooks/commit-msg $( git log --format=%s -n 1 "$commitish" )
   if [[ "$?" != "0" ]]; then


### PR DESCRIPTION
we should check only the commits pertaining to the PR being checked, not the full history.

Albeit arguably more correct (and equivalently safe) This is a workaround in disguise for a former resync which sneaked in a malformed commit.
