### PR TITLE
[release-4.13][KNI] build: envtest: remove 'latest' floating tag refs

### DIFF
--- a/Makefile.kni
+++ b/Makefile.kni
@@ -69,7 +69,7 @@ unit-test-quick: update-vendor
 
 .PHONY: install-envtest
 install-envtest: update-vendor
-	hack/install-envtest.sh
+	hack-kni/install-envtest.sh
 
 .PHONY: integration-test
 integration-test: install-envtest

--- a/hack-kni/install-envtest.sh
+++ b/hack-kni/install-envtest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is a helper script to install envtest
+# (https://github.com/kubernetes-sigs/controller-runtime/tree/master/pkg/envtest)
+# Mostly used by CI but can also be used for running integration tests locally.
+# Usage: `hack/install-envtest.sh`.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${SCRIPT_ROOT}/hack/lib/init.sh"
+
+# setup-envtest requires the version to be in the form of X.Y(.Z) (e.g. 1.23 or 1.23.3)
+# thus we want to remove the 'v' from the version extracted out of the go.mod file
+version=$(cat ${SCRIPT_ROOT}/go.mod | grep 'k8s.io/kubernetes' | grep -v '=>' | awk '{print $NF}' | awk 'BEGIN{FS=OFS="."}NF--' | sed 's/v//')
+
+GOPATH=$(go env GOPATH)
+TEMP_DIR=${TMPDIR-/tmp}
+# this is the last version before the bump golang 1.20 -> 1.22. We want to avoid the go.mod version format changes - for now.
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230927023946-553bd00cfec5
+"${GOPATH}"/bin/setup-envtest use -p env "${version}" > "${TEMP_DIR}/setup-envtest"
+


### PR DESCRIPTION
never use floating tags in the build system, not
even for CI tests. Always pin explicit versions.

Signed-off-by: Francesco Romani <fromani@redhat.com>
(cherry picked from commit 3326b7a3a63eaed11f6b11123962d75c7741854c)
