### PR TITLE
OCPBUGS-33514:  consume fix for ephemeral storage pods [resync 20240509]

### DIFF
--- a/RESYNC.log.md
+++ b/RESYNC.log.md
@@ -1,5 +1,6 @@
 | Resync Date | Merge With Upstream Tag/Commit                                                                       | Author      |
 |-------------|------------------------------------------------------------------------------------------------------|-------------|
+| 2023.05.09  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/89df67573f41083bcbb3e14f5120a27ea3784c2c | ffromani    | + cherry-picks on top
 | 2023.06.06  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/89df67573f41083bcbb3e14f5120a27ea3784c2c | ffromani    |
 | 2023.03.28  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ab6c864e24ca08a38efc609524ce10bce8d3db3b | ffromani    |
 | 2023.03.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/f303398b77c767ef1c6fab56ded0858a5dedbdd2 | ffromani    |

--- a/pkg/coscheduling/coscheduling_test.go
+++ b/pkg/coscheduling/coscheduling_test.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/scheduler-plugins/pkg/coscheduling/core"
 	fakepgclientset "sigs.k8s.io/scheduler-plugins/pkg/generated/clientset/versioned/fake"
 	pgformers "sigs.k8s.io/scheduler-plugins/pkg/generated/informers/externalversions"
-	"sigs.k8s.io/scheduler-plugins/test/util"
 	testutil "sigs.k8s.io/scheduler-plugins/test/util"
 )
 
@@ -101,31 +100,31 @@ func TestLess(t *testing.T) {
 		{
 			name: "p1.priority less than p2.priority",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
 		},
 		{
 			name: "p1.priority greater than p2.priority",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Obj()),
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
 				InitialAttemptTimestamp: times[1],
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -133,11 +132,11 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
 				InitialAttemptTimestamp: times[1],
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
@@ -145,31 +144,31 @@ func TestLess(t *testing.T) {
 		{
 			name: "p1.priority less than p2.priority, p1 belongs to podGroup1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
 		},
 		{
 			name: "p1.priority greater than p2.priority, p1 belongs to podGroup1",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Obj()),
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2, p1 belongs to podGroup3",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
 				InitialAttemptTimestamp: times[1],
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -177,11 +176,11 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to podGroup3",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
 				InitialAttemptTimestamp: times[1],
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
@@ -190,31 +189,31 @@ func TestLess(t *testing.T) {
 		{
 			name: "p1.priority less than p2.priority, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
 		},
 		{
 			name: "p1.priority greater than p2.priority, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo: util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				PodInfo: testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(lowPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
 		},
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
 				InitialAttemptTimestamp: times[1],
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -222,11 +221,11 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1, p1 belongs to podGroup4 and p2 belongs to podGroup3",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg4").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg4").Obj()),
 				InitialAttemptTimestamp: times[1],
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg3").Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			expected: false, // p2 should be ahead of p1 in the queue
@@ -234,11 +233,11 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority and creation time, p1 belongs to podGroup1 and p2 belongs to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg1").Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			expected: true, // p1 should be ahead of p2 in the queue
@@ -246,11 +245,11 @@ func TestLess(t *testing.T) {
 		{
 			name: "equal priority and creation time, p2 belong to podGroup2",
 			p1: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns1).Name("pod1").Priority(highPriority).Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			p2: &framework.QueuedPodInfo{
-				PodInfo:                 util.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
+				PodInfo:                 testutil.MustNewPodInfo(t, st.MakePod().Namespace(ns2).Name("pod2").Priority(highPriority).Label(v1alpha1.PodGroupLabel, "pg2").Obj()),
 				InitialAttemptTimestamp: times[0],
 			},
 			expected: true, // p1 should be ahead of p2 in the queue

--- a/pkg/networkaware/networkoverhead/networkoverhead.go
+++ b/pkg/networkaware/networkoverhead/networkoverhead.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	pluginconfig "sigs.k8s.io/scheduler-plugins/apis/config"
-	"sigs.k8s.io/scheduler-plugins/pkg/networkaware/util"
 	networkawareutil "sigs.k8s.io/scheduler-plugins/pkg/networkaware/util"
 
 	agv1alpha1 "github.com/diktyo-io/appgroup-api/pkg/apis/appgroup/v1alpha1"
@@ -89,7 +88,7 @@ type PreFilterState struct {
 	dependencyList []agv1alpha1.DependenciesInfo
 
 	// Pods already scheduled based on the dependency list
-	scheduledList util.ScheduledList
+	scheduledList networkawareutil.ScheduledList
 
 	// node map for cost / destinations. Search for requirements faster...
 	nodeCostMap map[string]map[networkawareutil.CostKey]int64

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -131,7 +131,9 @@ func resourcesAvailableInAnyNUMANodes(logID string, numaNodes NUMANodeList, reso
 			klog.V(6).InfoS("feasible", "logID", logID, "node", nodeName, "NUMA", numaNode.NUMAID, "resource", resource)
 		}
 
-		if !hasNUMAAffinity && !v1helper.IsNativeResource(resource) {
+		// non-native resources or ephemeral-storage may not expose NUMA affinity,
+		// but since they are available at node level, this is fine
+		if !hasNUMAAffinity && (!v1helper.IsNativeResource(resource) || resource == v1.ResourceEphemeralStorage) {
 			klog.V(6).InfoS("resource available at node level (no NUMA affinity)", "logID", logID, "node", nodeName, "resource", resource)
 			continue
 		}

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -661,6 +661,16 @@ func TestNodeResourceTopology(t *testing.T) {
 			node:       nodes[1],
 			wantStatus: nil,
 		},
+		{
+			name: "Guaranteed QoS, ephemeral-storage (non-NUMA), pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:              *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory:           resource.MustParse("2Gi"),
+				v1.ResourceEphemeralStorage: resource.MustParse("100Mi"),
+			}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
 	}
 
 	fakeClient := faketopologyv1alpha2.NewSimpleClientset()

--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -197,6 +197,9 @@ func findSuitableCombination(identifier string, qos v1.PodQOSClass, numaNodes NU
 		minDistance float32 = 256
 	)
 	for _, combination := range numaNodesCombination {
+		if isInvalidCombineResources(numaNodes, resources, combination) {
+			continue
+		}
 		combinationResources := combineResources(numaNodes, combination)
 		resourcesFit := checkResourcesFit(identifier, qos, resources, combinationResources)
 
@@ -229,4 +232,15 @@ func checkResourcesFit(identifier string, qos v1.PodQOSClass, resources v1.Resou
 	}
 
 	return true
+}
+
+func isInvalidCombineResources(numaNodes NUMANodeList, resources v1.ResourceList, combination []int) bool {
+	for _, nodeIndex := range combination {
+		for resourceName := range resources {
+			if _, ok := numaNodes[nodeIndex].Resources[resourceName]; !ok {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -137,10 +137,10 @@ func nodesAvgDistance(numaNodes NUMANodeList, nodes ...int) float32 {
 
 	for _, node1 := range nodes {
 		for _, node2 := range nodes {
-			cost, ok := numaNodes[node1].Costs[node2]
+			cost, ok := numaNodes[node1].Costs[numaNodes[node2].NUMAID]
 			// we couldn't read Costs assign maxDistanceValue
 			if !ok {
-				klog.Warningf("cannot retrieve Costs information for node %d", node2)
+				klog.Warningf("cannot retrieve Costs information for node ID %d", numaNodes[node1].NUMAID)
 				cost = maxDistanceValue
 			}
 			accu += cost
@@ -176,7 +176,9 @@ func numaNodesRequired(identifier string, qos v1.PodQOSClass, numaNodes NUMANode
 		// we have found suitable combination for given bitmaskLen
 		if suitableCombination != nil {
 			bm := bitmask.NewEmptyBitMask()
-			bm.Add(suitableCombination...)
+			for _, nodeIdx := range suitableCombination {
+				bm.Add(numaNodes[nodeIdx].NUMAID)
+			}
 			return bm, isMinDistance
 		}
 	}

--- a/pkg/noderesourcetopology/least_numa.go
+++ b/pkg/noderesourcetopology/least_numa.go
@@ -197,7 +197,7 @@ func findSuitableCombination(identifier string, qos v1.PodQOSClass, numaNodes NU
 		minDistance float32 = 256
 	)
 	for _, combination := range numaNodesCombination {
-		if isInvalidCombineResources(numaNodes, resources, combination) {
+		if !isValidCombineResources(numaNodes, resources, combination) {
 			continue
 		}
 		combinationResources := combineResources(numaNodes, combination)
@@ -234,13 +234,13 @@ func checkResourcesFit(identifier string, qos v1.PodQOSClass, resources v1.Resou
 	return true
 }
 
-func isInvalidCombineResources(numaNodes NUMANodeList, resources v1.ResourceList, combination []int) bool {
+func isValidCombineResources(numaNodes NUMANodeList, resources v1.ResourceList, combination []int) bool {
 	for _, nodeIndex := range combination {
 		for resourceName := range resources {
 			if _, ok := numaNodes[nodeIndex].Resources[resourceName]; !ok {
-				return true
+				return false
 			}
 		}
 	}
-	return false
+	return true
 }

--- a/pkg/noderesourcetopology/least_numa_test.go
+++ b/pkg/noderesourcetopology/least_numa_test.go
@@ -374,6 +374,104 @@ func TestNUMANodesRequired(t *testing.T) {
 			expectedMinDistance: true,
 		},
 		{
+			description: "8 NUMA node non optimal distance, not sorted ids, odd digit NUMA node without memory",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10, 1: 20, 2: 40, 3: 30, 4: 20, 5: 30, 6: 50, 7: 40,
+					},
+				},
+				{
+					NUMAID: 3,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 30, 1: 40, 2: 20, 3: 10, 4: 30, 5: 20, 6: 40, 7: 50,
+					},
+				},
+				{
+					NUMAID: 5,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 30, 1: 20, 2: 50, 3: 20, 4: 50, 5: 10, 6: 50, 7: 40,
+					},
+				},
+				{
+					NUMAID: 7,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 40, 1: 50, 2: 30, 3: 50, 4: 20, 5: 40, 6: 30, 7: 10,
+					},
+				},
+				{
+					NUMAID: 1,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 20, 1: 10, 2: 30, 3: 40, 4: 50, 5: 20, 6: 40, 7: 50,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 50, 1: 40, 2: 20, 3: 40, 4: 30, 5: 50, 6: 10, 7: 30,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 40, 1: 30, 2: 10, 3: 20, 4: 40, 5: 50, 6: 20, 7: 30,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20, 1: 50, 2: 40, 3: 30, 4: 10, 5: 50, 6: 30, 7: 20,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("3"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(2, 4, 6),
+			expectedErr:         nil,
+			expectedMinDistance: false,
+		},
+		{
 			description: "4 NUMA node optimal distance, non sequential ids",
 			numaNodes: NUMANodeList{
 				{
@@ -510,6 +608,74 @@ func TestNUMANodesRequired(t *testing.T) {
 			},
 			node:                node,
 			expectedBitmask:     NewTestBitmask(0, 6),
+			expectedErr:         nil,
+			expectedMinDistance: false,
+		},
+		{
+			description: "4 NUMA node non optimal distance, non sequential ids, NUMA node-2 and node-6 without memory",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10,
+						2: 12,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 12,
+						2: 10,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 10,
+						6: 12,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:    resource.MustParse("1"),
+						v1.ResourceCPU: *resource.NewQuantity(4, resource.DecimalSI),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 12,
+						6: 10,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("2"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(0, 4),
 			expectedErr:         nil,
 			expectedMinDistance: false,
 		},

--- a/pkg/noderesourcetopology/least_numa_test.go
+++ b/pkg/noderesourcetopology/least_numa_test.go
@@ -271,6 +271,248 @@ func TestNUMANodesRequired(t *testing.T) {
 			expectedErr:         nil,
 			expectedMinDistance: false,
 		},
+		{
+			description: "8 NUMA node optimal distance, not sorted ids",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10, 1: 20, 2: 40, 3: 30, 4: 20, 5: 30, 6: 50, 7: 40,
+					},
+				},
+				{
+					NUMAID: 3,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 30, 1: 40, 2: 20, 3: 10, 4: 30, 5: 20, 6: 40, 7: 50,
+					},
+				},
+				{
+					NUMAID: 5,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 30, 1: 20, 2: 50, 3: 20, 4: 50, 5: 10, 6: 50, 7: 40,
+					},
+				},
+				{
+					NUMAID: 7,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 40, 1: 50, 2: 30, 3: 50, 4: 20, 5: 40, 6: 30, 7: 10,
+					},
+				},
+				{
+					NUMAID: 1,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20, 1: 10, 2: 30, 3: 40, 4: 50, 5: 20, 6: 40, 7: 50,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 50, 1: 40, 2: 20, 3: 40, 4: 30, 5: 50, 6: 10, 7: 30,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 40, 1: 30, 2: 10, 3: 20, 4: 40, 5: 50, 6: 20, 7: 30,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20, 1: 50, 2: 40, 3: 30, 4: 10, 5: 50, 6: 30, 7: 20,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("3"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(0, 1, 5),
+			expectedErr:         nil,
+			expectedMinDistance: true,
+		},
+		{
+			description: "4 NUMA node optimal distance, non sequential ids",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10,
+						2: 12,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 12,
+						2: 10,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("0"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 10,
+						6: 12,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("0"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 12,
+						6: 10,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("2"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(0, 2),
+			expectedErr:         nil,
+			expectedMinDistance: true,
+		},
+		{
+			description: "4 NUMA node non optimal distance, non sequential ids",
+			numaNodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 10,
+						2: 12,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 2,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("0"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 12,
+						2: 10,
+						4: 20,
+						6: 20,
+					},
+				},
+				{
+					NUMAID: 4,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("0"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 10,
+						6: 12,
+					},
+				},
+				{
+					NUMAID: 6,
+					Resources: v1.ResourceList{
+						gpuResource:       resource.MustParse("1"),
+						v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+						v1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+					Costs: map[int]int{
+						0: 20,
+						2: 20,
+						4: 12,
+						6: 10,
+					},
+				},
+			},
+			podResources: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				gpuResource:       resource.MustParse("2"),
+			},
+			node:                node,
+			expectedBitmask:     NewTestBitmask(0, 6),
+			expectedErr:         nil,
+			expectedMinDistance: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/integration/elasticquota_controller_test.go
+++ b/test/integration/elasticquota_controller_test.go
@@ -38,7 +38,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/scheduler-plugins/apis/scheduling"
-	"sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	schedv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	"sigs.k8s.io/scheduler-plugins/pkg/capacityscheduling"
 	"sigs.k8s.io/scheduler-plugins/pkg/controllers"
@@ -128,15 +127,15 @@ func TestElasticController(t *testing.T) {
 
 	for _, tt := range []struct {
 		name          string
-		elasticQuotas []*v1alpha1.ElasticQuota
+		elasticQuotas []*schedv1alpha1.ElasticQuota
 		existingPods  []*v1.Pod
-		used          []*v1alpha1.ElasticQuota
+		used          []*schedv1alpha1.ElasticQuota
 		incomingPods  []*v1.Pod
-		want          []*v1alpha1.ElasticQuota
+		want          []*schedv1alpha1.ElasticQuota
 	}{
 		{
 			name: "The status of the pod changes from pending to running",
-			elasticQuotas: []*v1alpha1.ElasticQuota{
+			elasticQuotas: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t1-eq1").
 					Min(MakeResourceList().CPU(100).Mem(1000).Obj()).
 					Max(MakeResourceList().CPU(100).Mem(1000).Obj()).Obj(),
@@ -154,7 +153,7 @@ func TestElasticController(t *testing.T) {
 				MakePod("ns2", "t1-p4").
 					Container(MakeResourceList().CPU(10).Mem(10).Obj()).Obj(),
 			},
-			used: []*v1alpha1.ElasticQuota{
+			used: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t1-eq1").
 					Used(MakeResourceList().CPU(0).Mem(0).Obj()).Obj(),
 				MakeEQ("ns2", "t1-eq2").
@@ -171,7 +170,7 @@ func TestElasticController(t *testing.T) {
 					Container(MakeResourceList().CPU(10).Mem(10).Obj()).Obj(),
 			},
 
-			want: []*v1alpha1.ElasticQuota{
+			want: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t1-eq1").
 					Used(MakeResourceList().CPU(30).Mem(40).Obj()).Obj(),
 				MakeEQ("ns2", "t1-eq2").
@@ -180,7 +179,7 @@ func TestElasticController(t *testing.T) {
 		},
 		{
 			name: "The status of the pod changes from running to others",
-			elasticQuotas: []*v1alpha1.ElasticQuota{
+			elasticQuotas: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t2-eq1").
 					Min(MakeResourceList().CPU(100).Mem(1000).Obj()).
 					Max(MakeResourceList().CPU(100).Mem(1000).Obj()).Obj(),
@@ -198,7 +197,7 @@ func TestElasticController(t *testing.T) {
 				MakePod("ns2", "t2-p4").Phase(v1.PodRunning).Node("fake-node").
 					Container(MakeResourceList().CPU(10).Mem(10).Obj()).Obj(),
 			},
-			used: []*v1alpha1.ElasticQuota{
+			used: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t2-eq1").
 					Used(MakeResourceList().CPU(30).Mem(40).Obj()).Obj(),
 				MakeEQ("ns2", "t2-eq2").
@@ -208,7 +207,7 @@ func TestElasticController(t *testing.T) {
 				MakePod("ns1", "t2-p1").Phase(v1.PodSucceeded).Obj(),
 				MakePod("ns1", "t2-p3").Phase(v1.PodFailed).Obj(),
 			},
-			want: []*v1alpha1.ElasticQuota{
+			want: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t2-eq1").
 					Used(MakeResourceList().CPU(10).Mem(10).Obj()).Obj(),
 				MakeEQ("ns2", "t2-eq2").
@@ -217,7 +216,7 @@ func TestElasticController(t *testing.T) {
 		},
 		{
 			name: "Different resource between max and min",
-			elasticQuotas: []*v1alpha1.ElasticQuota{
+			elasticQuotas: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t3-eq1").
 					Min(MakeResourceList().Mem(1000).Obj()).
 					Max(MakeResourceList().CPU(100).Obj()).Obj(),
@@ -226,7 +225,7 @@ func TestElasticController(t *testing.T) {
 				MakePod("ns1", "t3-p1").
 					Container(MakeResourceList().CPU(10).Mem(20).Obj()).Obj(),
 			},
-			used: []*v1alpha1.ElasticQuota{
+			used: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t3-eq1").
 					Used(MakeResourceList().CPU(0).Mem(0).Obj()).Obj(),
 			},
@@ -234,14 +233,14 @@ func TestElasticController(t *testing.T) {
 				MakePod("ns1", "t3-p1").Phase(v1.PodRunning).Node("fake-node").
 					Container(MakeResourceList().CPU(10).Mem(20).Obj()).Obj(),
 			},
-			want: []*v1alpha1.ElasticQuota{
+			want: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t3-eq1").
 					Used(MakeResourceList().CPU(10).Mem(20).Obj()).Obj(),
 			},
 		},
 		{
 			name: "EQ doesn't have max and the status of the pod changes from pending to running",
-			elasticQuotas: []*v1alpha1.ElasticQuota{
+			elasticQuotas: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t4-eq1").
 					Min(MakeResourceList().CPU(10).Mem(10).Obj()).Obj(),
 			},
@@ -255,7 +254,7 @@ func TestElasticController(t *testing.T) {
 				MakePod("ns1", "t4-p4").
 					Container(MakeResourceList().CPU(10).Mem(10).Obj()).Obj(),
 			},
-			used: []*v1alpha1.ElasticQuota{
+			used: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t4-eq1").
 					Used(MakeResourceList().CPU(0).Mem(0).Obj()).Obj(),
 			},
@@ -270,7 +269,7 @@ func TestElasticController(t *testing.T) {
 					Container(MakeResourceList().CPU(10).Mem(10).Obj()).Obj(),
 			},
 
-			want: []*v1alpha1.ElasticQuota{
+			want: []*schedv1alpha1.ElasticQuota{
 				MakeEQ("ns1", "t4-eq1").
 					Used(MakeResourceList().CPU(40).Mem(50).Obj()).Obj(),
 			},

--- a/test/integration/noderesourcetopology_cache_test.go
+++ b/test/integration/noderesourcetopology_cache_test.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler"
@@ -477,7 +476,7 @@ func TestTopologyCachePluginWithoutUpdates(t *testing.T) {
 			testCtx := &testContext{}
 			testCtx.Ctx, testCtx.CancelFn = context.WithCancel(context.Background())
 
-			cs := kubernetes.NewForConfigOrDie(globalKubeConfig)
+			cs := clientset.NewForConfigOrDie(globalKubeConfig)
 			extClient := versioned.NewForConfigOrDie(globalKubeConfig)
 			testCtx.ClientSet = cs
 			testCtx.KubeConfig = globalKubeConfig
@@ -658,7 +657,7 @@ func TestTopologyCachePluginWithUpdates(t *testing.T) {
 	testCtx := &testContext{}
 	testCtx.Ctx, testCtx.CancelFn = context.WithCancel(context.Background())
 
-	cs := kubernetes.NewForConfigOrDie(globalKubeConfig)
+	cs := clientset.NewForConfigOrDie(globalKubeConfig)
 	extClient := versioned.NewForConfigOrDie(globalKubeConfig)
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig

--- a/test/integration/noderesourcetopology_test.go
+++ b/test/integration/noderesourcetopology_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
@@ -95,7 +94,7 @@ func TestTopologyMatchPluginValidation(t *testing.T) {
 		},
 	})
 
-	cs := kubernetes.NewForConfigOrDie(globalKubeConfig)
+	cs := clientset.NewForConfigOrDie(globalKubeConfig)
 	informer := scheduler.NewInformerFactory(cs, 0)
 	dynInformerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynamic.NewForConfigOrDie(globalKubeConfig), 0, v1.NamespaceAll, nil)
 	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{
@@ -127,7 +126,7 @@ func TestTopologyMatchPlugin(t *testing.T) {
 	testCtx := &testContext{}
 	testCtx.Ctx, testCtx.CancelFn = context.WithCancel(context.Background())
 
-	cs := kubernetes.NewForConfigOrDie(globalKubeConfig)
+	cs := clientset.NewForConfigOrDie(globalKubeConfig)
 	extClient := versioned.NewForConfigOrDie(globalKubeConfig)
 	testCtx.ClientSet = cs
 	testCtx.KubeConfig = globalKubeConfig

--- a/test/integration/nrtutils.go
+++ b/test/integration/nrtutils.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -48,7 +47,7 @@ const (
 	nicResourceName = "vendor/nic1"
 )
 
-func waitForNRT(cs *kubernetes.Clientset) error {
+func waitForNRT(cs *clientset.Clientset) error {
 	return wait.Poll(100*time.Millisecond, 3*time.Second, func() (done bool, err error) {
 		groupList, _, err := cs.ServerGroupsAndResources()
 		if err != nil {


### PR DESCRIPTION
Add cherry-picks on top of current version:
https://github.com/openshift-kni/scheduler-plugins/commit/96fcf6df77a8a003ab6effeeae3b6240f4181959 https://github.com/openshift-kni/scheduler-plugins/commit/0519d055094f6912d60541421fbc9d82571c1c84 https://github.com/openshift-kni/scheduler-plugins/commit/23e7ea896720e33fa6d923b01871b983bed4aa64 https://github.com/openshift-kni/scheduler-plugins/commit/b5d4ee32619fd755118ddca1fa950ba62f8cc9af https://github.com/openshift-kni/scheduler-plugins/commit/cd54de85fe4d5cce32a5b71e59a4b0f9a7f7dddf
update the NRT-related changes to consume the
fix to deal with ephemeral storage.