### PR TITLE
OCPBUGS-33359: consume fix for ephemeral storage pods [resync 20240509]

### DIFF
--- a/RESYNC.log.md
+++ b/RESYNC.log.md
@@ -1,5 +1,6 @@
 | Resync Date | Merge With Upstream Tag/Commit                                                                       | Author      |
 |-------------|------------------------------------------------------------------------------------------------------|-------------|
+| 2024.05.09  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/bc9480d3132a50a6c233bd1fff77df03c86f68a2 | Tal-or      | + cherry-picks on top (ffromani)
 | 2023.05.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/bc9480d3132a50a6c233bd1fff77df03c86f68a2 | Tal-or      |
 | 2022.10.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/81fb4607af1d45ebf76eb7fbd0eb7ddba7abc959 | swatisehgal |
 | 2022.07.06  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/6aadda4e9213fd0f71807cd6630eb8e58db740fd | swatisehgal |

--- a/RESYNC.log.md
+++ b/RESYNC.log.md
@@ -1,0 +1,12 @@
+| Resync Date | Merge With Upstream Tag/Commit                                                                       | Author      |
+|-------------|------------------------------------------------------------------------------------------------------|-------------|
+| 2023.05.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/bc9480d3132a50a6c233bd1fff77df03c86f68a2 | Tal-or      |
+| 2022.10.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/81fb4607af1d45ebf76eb7fbd0eb7ddba7abc959 | swatisehgal |
+| 2022.07.06  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/6aadda4e9213fd0f71807cd6630eb8e58db740fd | swatisehgal |
+| 2022.06.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/843d47374bba691f13558806e8fddb866bfb1b9e | swatisehgal |
+| 2022.06.23  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/54bd848cd75ce5c0b6953733b0e477c47aa356a9 | swatisehgal |
+| 2022.05.03  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/7a6dcdc99b1ee9a324823eaf98718cfd9e98e805 | fromanirh   |
+| 2022.03.10  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/2b3439076c54579c3ecdacfc71ca00a23f1e42f8 | fromanirh   |
+| 2022.01.21  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ec632c3d7e04b7b372f9a6f4338b0dbc53ef3d46 | fromanirh   |
+| 2021.12.23  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/7cf6512bd726f0d30b2ab32443af867a0b849da8 | fromanirh   |
+| 2021.12.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/b8d13e17a3e1f633d72d71276a3da6fecf89f2e3 | Tal-or      |

--- a/RESYNC.md
+++ b/RESYNC.md
@@ -38,22 +38,7 @@ at the beginning of the commit message.
 
 ### Document changes
 
-For the sake of transparency, for every resync process we should update the following table:
-
-| Resync Date | Merge With Upstream Tag/Commit                                                                       | Author      |
-|-------------|------------------------------------------------------------------------------------------------------|-------------|
-| 2023.05.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/bc9480d3132a50a6c233bd1fff77df03c86f68a2 | Tal-or      |
-| 2022.10.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/81fb4607af1d45ebf76eb7fbd0eb7ddba7abc959 | swatisehgal |
-| 2022.07.06  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/6aadda4e9213fd0f71807cd6630eb8e58db740fd | swatisehgal |
-| 2022.06.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/843d47374bba691f13558806e8fddb866bfb1b9e | swatisehgal |
-| 2022.06.23  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/54bd848cd75ce5c0b6953733b0e477c47aa356a9 | swatisehgal |
-| 2022.05.03  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/7a6dcdc99b1ee9a324823eaf98718cfd9e98e805 | fromanirh   |
-| 2022.03.10  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/2b3439076c54579c3ecdacfc71ca00a23f1e42f8 | fromanirh   |
-| 2022.01.21  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ec632c3d7e04b7b372f9a6f4338b0dbc53ef3d46 | fromanirh   |
-| 2021.12.23  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/7cf6512bd726f0d30b2ab32443af867a0b849da8 | fromanirh   |
-| 2021.12.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/b8d13e17a3e1f633d72d71276a3da6fecf89f2e3 | Tal-or      |
-
-The newest resync should appear in the first row. 
+For the sake of transparency, for every resync process we should update the table in `RESYNC.log.md`. The newest resync should appear in the first row.
 
 ## Release Branch Upstream Resync Strategy
 

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -131,7 +131,9 @@ func resourcesAvailableInAnyNUMANodes(logID string, numaNodes NUMANodeList, reso
 			klog.V(6).InfoS("feasible", "logID", logID, "node", nodeName, "NUMA", numaNode.NUMAID, "resource", resource)
 		}
 
-		if !hasNUMAAffinity && !v1helper.IsNativeResource(resource) {
+		// non-native resources or ephemeral-storage may not expose NUMA affinity,
+		// but since they are available at node level, this is fine
+		if !hasNUMAAffinity && (!v1helper.IsNativeResource(resource) || resource == v1.ResourceEphemeralStorage) {
 			klog.V(6).InfoS("resource available at node level (no NUMA affinity)", "logID", logID, "node", nodeName, "resource", resource)
 			continue
 		}

--- a/pkg/noderesourcetopology/filter_test.go
+++ b/pkg/noderesourcetopology/filter_test.go
@@ -661,6 +661,16 @@ func TestNodeResourceTopology(t *testing.T) {
 			node:       nodes[1],
 			wantStatus: nil,
 		},
+		{
+			name: "Guaranteed QoS, ephemeral-storage (non-NUMA), pod fit",
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:              *resource.NewQuantity(2, resource.DecimalSI),
+				v1.ResourceMemory:           resource.MustParse("2Gi"),
+				v1.ResourceEphemeralStorage: resource.MustParse("100Mi"),
+			}),
+			node:       nodes[1],
+			wantStatus: nil,
+		},
 	}
 
 	fakeClient := faketopologyv1alpha2.NewSimpleClientset()


### PR DESCRIPTION
Add cherry-picks on top of current version:
https://github.com/openshift-kni/scheduler-plugins/commit/cd54de85fe4d5cce32a5b71e59a4b0f9a7f7dddf
update the NRT-related changes to consume the
fix to deal with ephemeral storage.