### PR TITLE
[release-4.12] resync 20240610

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
@@ -78,7 +77,12 @@ func singleNUMAContainerLevelHandler(pod *v1.Pod, zones topologyv1alpha2.ZoneLis
 
 		// subtract the resources requested by the container from the given NUMA.
 		// this is necessary, so we won't allocate the same resources for the upcoming containers
-		subtractFromNUMA(nodes, numaID, container)
+		err := subtractResourcesFromNUMANodeList(clh, nodes, numaID, qos, container.Resources.Requests)
+		if err != nil {
+			// this is an internal error which should never happen
+			return framework.NewStatus(framework.Error, "inconsistent resource accounting", err.Error())
+		}
+		clh.V(4).Info("container aligned", "numaCell", numaID)
 	}
 	return nil
 }
@@ -155,13 +159,6 @@ func resourcesAvailableInAnyNUMANodes(logID string, numaNodes NUMANodeList, reso
 	return numaID, ret
 }
 
-func isResourceSetSuitable(qos v1.PodQOSClass, resource v1.ResourceName, quantity, numaQuantity resource.Quantity) bool {
-	if qos != v1.PodQOSGuaranteed && isNUMAAffineResource(resource) {
-		return true
-	}
-	return numaQuantity.Cmp(quantity) >= 0
-}
-
 func singleNUMAPodLevelHandler(pod *v1.Pod, zones topologyv1alpha2.ZoneList, nodeInfo *framework.NodeInfo) *framework.Status {
 	klog.V(5).InfoS("Pod Level Resource handler")
 
@@ -211,28 +208,6 @@ func (tm *TopologyMatch) Filter(ctx context.Context, cycleState *framework.Cycle
 		tm.nrtCache.NodeMaybeOverReserved(nodeName, pod)
 	}
 	return status
-}
-
-// subtractFromNUMA finds the correct NUMA ID's resources and subtract them from `nodes`.
-func subtractFromNUMA(nodes NUMANodeList, numaID int, container v1.Container) {
-	for i := 0; i < len(nodes); i++ {
-		if nodes[i].NUMAID != numaID {
-			continue
-		}
-
-		nRes := nodes[i].Resources
-		for resName, quan := range container.Resources.Requests {
-			nodeResQuan := nRes[resName]
-			nodeResQuan.Sub(quan)
-			// we do not expect a negative value here, since this function only called
-			// when resourcesAvailableInAnyNUMANodes function is passed
-			// but let's log here if such unlikely case will occur
-			if nodeResQuan.Sign() == -1 {
-				klog.V(4).InfoS("resource quantity should not be a negative value", "resource", resName, "quantity", nodeResQuan.String())
-			}
-			nRes[resName] = nodeResQuan
-		}
-	}
 }
 
 func filterHandlerFromTopologyManagerConfig(conf TopologyManagerConfig) filterFn {

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -133,7 +133,7 @@ func resourcesAvailableInAnyNUMANodes(logID string, numaNodes NUMANodeList, reso
 
 		// non-native resources or ephemeral-storage may not expose NUMA affinity,
 		// but since they are available at node level, this is fine
-		if !hasNUMAAffinity && (!v1helper.IsNativeResource(resource) || resource == v1.ResourceEphemeralStorage) {
+		if !hasNUMAAffinity && isHostLevelResource(resource) {
 			klog.V(6).InfoS("resource available at node level (no NUMA affinity)", "logID", logID, "node", nodeName, "resource", resource)
 			continue
 		}

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	bm "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
@@ -157,21 +156,9 @@ func resourcesAvailableInAnyNUMANodes(logID string, numaNodes NUMANodeList, reso
 }
 
 func isResourceSetSuitable(qos v1.PodQOSClass, resource v1.ResourceName, quantity, numaQuantity resource.Quantity) bool {
-	// Check for the following:
-	if qos != v1.PodQOSGuaranteed {
-		// 1. set numa node as possible node if resource is memory or Hugepages
-		if resource == v1.ResourceMemory {
-			return true
-		}
-		if v1helper.IsHugePageResourceName(resource) {
-			return true
-		}
-		// 2. set numa node as possible node if resource is CPU
-		if resource == v1.ResourceCPU {
-			return true
-		}
+	if qos != v1.PodQOSGuaranteed && isNUMAAffineResource(resource) {
+		return true
 	}
-	// 3. otherwise check amount of resources
 	return numaQuantity.Cmp(quantity) >= 0
 }
 

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	bm "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
@@ -77,7 +78,8 @@ func singleNUMAContainerLevelHandler(pod *v1.Pod, zones topologyv1alpha2.ZoneLis
 
 		// subtract the resources requested by the container from the given NUMA.
 		// this is necessary, so we won't allocate the same resources for the upcoming containers
-		err := subtractResourcesFromNUMANodeList(clh, nodes, numaID, qos, container.Resources.Requests)
+		clh := klogr.New().WithValues("logID", logID, "node", nodeInfo.Node().Name)
+		err := subtractResourcesFromNUMANodeList(clh, nodes, numaID, qos, container.Resources.Requests, logID)
 		if err != nil {
 			// this is an internal error which should never happen
 			return framework.NewStatus(framework.Error, "inconsistent resource accounting", err.Error())

--- a/pkg/noderesourcetopology/numaresources.go
+++ b/pkg/noderesourcetopology/numaresources.go
@@ -35,3 +35,20 @@ func isHostLevelResource(resource corev1.ResourceName) bool {
 	}
 	return false
 }
+
+func isNUMAAffineResource(resource corev1.ResourceName) bool {
+	// NUMA-affine resources are resources which are required to be bound to NUMA nodes.
+	// A Key example is CPU and memory, which must expose NUMA affinity.
+	if resource == corev1.ResourceCPU {
+		return true
+	}
+	if resource == corev1.ResourceMemory {
+		return true
+	}
+	if v1helper.IsHugePageResourceName(resource) {
+		return true
+	}
+	// Devices are *expected* to expose NUMA Affinity, but they are not *required* to do so.
+	// We can't tell for sure, so we default to "no".
+	return false
+}

--- a/pkg/noderesourcetopology/numaresources.go
+++ b/pkg/noderesourcetopology/numaresources.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesourcetopology
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+)
+
+func isHostLevelResource(resource corev1.ResourceName) bool {
+	// host-level resources are resources which *may* not be bound to NUMA nodes.
+	// A Key example is generic [ephemeral] storage which doesn't expose NUMA affinity.
+	if resource == corev1.ResourceEphemeralStorage {
+		return true
+	}
+	if resource == corev1.ResourceStorage {
+		return true
+	}
+	if !v1helper.IsNativeResource(resource) {
+		return true
+	}
+	return false
+}

--- a/pkg/noderesourcetopology/numaresources.go
+++ b/pkg/noderesourcetopology/numaresources.go
@@ -140,7 +140,7 @@ func isResourceSetSuitable(qos corev1.PodQOSClass, resource corev1.ResourceName,
 }
 
 // subtractResourcesFromNUMANodeList finds the correct NUMA ID's resources and always subtract them from `nodes` in-place.
-func subtractResourcesFromNUMANodeList(lh logr.Logger, nodes NUMANodeList, numaID int, qos corev1.PodQOSClass, containerRes corev1.ResourceList) error {
+func subtractResourcesFromNUMANodeList(lh logr.Logger, nodes NUMANodeList, numaID int, qos corev1.PodQOSClass, containerRes corev1.ResourceList, logID string) error {
 	logEntries := []any{"numaCell", numaID}
 
 	for _, node := range nodes {
@@ -148,7 +148,7 @@ func subtractResourcesFromNUMANodeList(lh logr.Logger, nodes NUMANodeList, numaI
 			continue
 		}
 
-		lh.V(5).Info("NUMA resources before", append(logEntries, stringify.ResourceListToLoggable(node.Resources)...)...)
+		lh.V(5).Info("NUMA resources before", append(logEntries, stringify.ResourceListToLoggable(logID, node.Resources)...)...)
 
 		for resName, resQty := range containerRes {
 			isAffine := isNUMAAffineResource(resName)
@@ -174,7 +174,7 @@ func subtractResourcesFromNUMANodeList(lh logr.Logger, nodes NUMANodeList, numaI
 			node.Resources[resName] = nodeResQty
 		}
 
-		lh.V(5).Info("NUMA resources after", append(logEntries, stringify.ResourceListToLoggable(node.Resources)...)...)
+		lh.V(5).Info("NUMA resources after", append(logEntries, stringify.ResourceListToLoggable(logID, node.Resources)...)...)
 	}
 	return nil
 }

--- a/pkg/noderesourcetopology/numaresources_test.go
+++ b/pkg/noderesourcetopology/numaresources_test.go
@@ -65,3 +65,47 @@ func TestIsHostLevelResource(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNUMAAffineResource(t *testing.T) {
+	testCases := []struct {
+		resource corev1.ResourceName
+		expected bool
+	}{
+		{
+			resource: corev1.ResourceCPU,
+			expected: true,
+		},
+		{
+			resource: corev1.ResourceMemory,
+			expected: true,
+		},
+		{
+			resource: corev1.ResourceName("hugepages-1Gi"),
+			expected: true,
+		},
+		{
+			resource: corev1.ResourceStorage,
+			expected: false,
+		},
+		{
+			resource: corev1.ResourceEphemeralStorage,
+			expected: false,
+		},
+		{
+			resource: corev1.ResourceName("vendor.io/fastest-nic"),
+			expected: false,
+		},
+		{
+			resource: corev1.ResourceName("awesome.com/gpu-for-ai"),
+			expected: false,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(string(testCase.resource), func(t *testing.T) {
+			got := isNUMAAffineResource(testCase.resource)
+			if got != testCase.expected {
+				t.Fatalf("expected %t to equal %t", got, testCase.expected)
+			}
+		})
+	}
+}

--- a/pkg/noderesourcetopology/numaresources_test.go
+++ b/pkg/noderesourcetopology/numaresources_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package noderesourcetopology
 
 import (
+	"fmt"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2/ktesting"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -108,4 +112,270 @@ func TestIsNUMAAffineResource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubtractResourcesFromNUMANodeList(t *testing.T) {
+	testCases := []struct {
+		name          string
+		nodes         NUMANodeList
+		numaID        int
+		qos           corev1.PodQOSClass
+		containerRes  corev1.ResourceList
+		expected      NUMANodeList
+		expectedError error
+	}{
+		{
+			name: "empty from empty",
+			nodes: NUMANodeList{
+				{
+					NUMAID:    0,
+					Resources: corev1.ResourceList{},
+				},
+			},
+			numaID:       0,
+			qos:          corev1.PodQOSGuaranteed,
+			containerRes: corev1.ResourceList{},
+			expected: NUMANodeList{
+				{
+					NUMAID:    0,
+					Resources: corev1.ResourceList{},
+				},
+			},
+		},
+		{
+			name: "inconsistent numaID",
+			nodes: NUMANodeList{
+				{
+					NUMAID:    0,
+					Resources: corev1.ResourceList{},
+				},
+			},
+			numaID:       2,
+			qos:          corev1.PodQOSGuaranteed,
+			containerRes: corev1.ResourceList{},
+			expected: NUMANodeList{
+				{
+					NUMAID:    0,
+					Resources: corev1.ResourceList{},
+				},
+			},
+		},
+		{
+			name: "empty from minimal",
+			nodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "2"),
+						corev1.ResourceMemory: mustParseQuantity(t, "4Gi"),
+					},
+				},
+			},
+			numaID:       0,
+			qos:          corev1.PodQOSGuaranteed,
+			containerRes: corev1.ResourceList{},
+			expected: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "2"),
+						corev1.ResourceMemory: mustParseQuantity(t, "4Gi"),
+					},
+				},
+			},
+		},
+		{
+			name: "remove core resources (GU qos)",
+			nodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "8"),
+						corev1.ResourceMemory: mustParseQuantity(t, "16Gi"),
+					},
+				},
+			},
+			numaID: 0,
+			qos:    corev1.PodQOSGuaranteed,
+			containerRes: corev1.ResourceList{
+				corev1.ResourceCPU:    mustParseQuantity(t, "2"),
+				corev1.ResourceMemory: mustParseQuantity(t, "4Gi"),
+			},
+			expected: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "6"),
+						corev1.ResourceMemory: mustParseQuantity(t, "12Gi"),
+					},
+				},
+			},
+		},
+		{
+			name: "remove only devices resources (BU qos)",
+			nodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:                   mustParseQuantity(t, "8"),
+						corev1.ResourceMemory:                mustParseQuantity(t, "16Gi"),
+						corev1.ResourceName("vendor.io/gpu"): mustParseQuantity(t, "4"),
+					},
+				},
+			},
+			numaID: 0,
+			qos:    corev1.PodQOSBurstable,
+			containerRes: corev1.ResourceList{
+				corev1.ResourceCPU:                   mustParseQuantity(t, "2"),
+				corev1.ResourceMemory:                mustParseQuantity(t, "4Gi"),
+				corev1.ResourceName("vendor.io/gpu"): mustParseQuantity(t, "2"),
+			},
+			expected: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:                   mustParseQuantity(t, "8"),
+						corev1.ResourceMemory:                mustParseQuantity(t, "16Gi"),
+						corev1.ResourceName("vendor.io/gpu"): mustParseQuantity(t, "2"),
+					},
+				},
+			},
+		},
+		{
+			name: "skip hostlevel resources (GU qos)",
+			nodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:                   mustParseQuantity(t, "8"),
+						corev1.ResourceMemory:                mustParseQuantity(t, "16Gi"),
+						corev1.ResourceName("vendor.io/nic"): mustParseQuantity(t, "4"),
+					},
+				},
+			},
+			numaID: 0,
+			qos:    corev1.PodQOSGuaranteed,
+			containerRes: corev1.ResourceList{
+				corev1.ResourceCPU:                   mustParseQuantity(t, "6"),
+				corev1.ResourceMemory:                mustParseQuantity(t, "12Gi"),
+				corev1.ResourceName("vendor.io/nic"): mustParseQuantity(t, "2"),
+				corev1.ResourceEphemeralStorage:      mustParseQuantity(t, "1Gi"),
+			},
+			expected: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:                   mustParseQuantity(t, "2"),
+						corev1.ResourceMemory:                mustParseQuantity(t, "4Gi"),
+						corev1.ResourceName("vendor.io/nic"): mustParseQuantity(t, "2"),
+					},
+				},
+			},
+		},
+		{
+			name: "remove excessive core resources (GU qos)",
+			nodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "8"),
+						corev1.ResourceMemory: mustParseQuantity(t, "16Gi"),
+					},
+				},
+			},
+			numaID: 0,
+			qos:    corev1.PodQOSGuaranteed,
+			containerRes: corev1.ResourceList{
+				corev1.ResourceCPU:    mustParseQuantity(t, "10"),
+				corev1.ResourceMemory: mustParseQuantity(t, "20Gi"),
+			},
+			expected: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "8"),
+						corev1.ResourceMemory: mustParseQuantity(t, "16Gi"),
+					},
+				},
+			},
+			expectedError: fmt.Errorf("resource %q request %s exceeds NUMA %d availability %s", corev1.ResourceCPU, "10", 0, "8"),
+		},
+		{
+			name: "require missing resources (GU qos, device)",
+			nodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "8"),
+						corev1.ResourceMemory: mustParseQuantity(t, "16Gi"),
+					},
+				},
+			},
+			numaID: 0,
+			qos:    corev1.PodQOSGuaranteed,
+			containerRes: corev1.ResourceList{
+				corev1.ResourceCPU:                   mustParseQuantity(t, "4"),
+				corev1.ResourceMemory:                mustParseQuantity(t, "8Gi"),
+				corev1.ResourceName("vendor.io/gpu"): mustParseQuantity(t, "2"),
+			},
+			expected: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "4"),
+						corev1.ResourceMemory: mustParseQuantity(t, "8Gi"),
+					},
+				},
+			},
+		},
+		{
+			name: "require missing resources (GU qos, core)",
+			nodes: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "8"),
+						corev1.ResourceMemory: mustParseQuantity(t, "16Gi"),
+					},
+				},
+			},
+			numaID: 0,
+			qos:    corev1.PodQOSGuaranteed,
+			containerRes: corev1.ResourceList{
+				corev1.ResourceCPU:                   mustParseQuantity(t, "4"),
+				corev1.ResourceMemory:                mustParseQuantity(t, "8Gi"),
+				corev1.ResourceName("hugepages-1Gi"): mustParseQuantity(t, "2Gi"),
+			},
+			expected: NUMANodeList{
+				{
+					NUMAID: 0,
+					Resources: corev1.ResourceList{
+						corev1.ResourceCPU:    mustParseQuantity(t, "4"),
+						corev1.ResourceMemory: mustParseQuantity(t, "8Gi"),
+					},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(string(testCase.name), func(t *testing.T) {
+			nodes := testCase.nodes.DeepCopy()
+			logh := ktesting.NewLogger(t, ktesting.DefaultConfig)
+			err := subtractResourcesFromNUMANodeList(logh, nodes, testCase.numaID, testCase.qos, testCase.containerRes)
+			if (err != nil) != (testCase.expectedError != nil) {
+				t.Fatalf("got err %v expected err %v", err, testCase.expectedError)
+			}
+			if err == nil && !nodes.Equal(testCase.expected) {
+				t.Errorf("got %#v expected %#v", nodes, testCase.expected)
+			}
+		})
+	}
+}
+
+func mustParseQuantity(t *testing.T, str string) resource.Quantity {
+	qty, err := resource.ParseQuantity(str)
+	if err != nil {
+		t.Fatalf("parsing error: %v", err)
+	}
+	return qty
 }

--- a/pkg/noderesourcetopology/numaresources_test.go
+++ b/pkg/noderesourcetopology/numaresources_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesourcetopology
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIsHostLevelResource(t *testing.T) {
+	testCases := []struct {
+		resource corev1.ResourceName
+		expected bool
+	}{
+		{
+			resource: corev1.ResourceCPU,
+			expected: false,
+		},
+		{
+			resource: corev1.ResourceMemory,
+			expected: false,
+		},
+		{
+			resource: corev1.ResourceName("hugepages-1Gi"),
+			expected: false,
+		},
+		{
+			resource: corev1.ResourceStorage,
+			expected: true,
+		},
+		{
+			resource: corev1.ResourceEphemeralStorage,
+			expected: true,
+		},
+		{
+			resource: corev1.ResourceName("vendor.io/fastest-nic"),
+			expected: true,
+		},
+		{
+			resource: corev1.ResourceName("awesome.com/gpu-for-ai"),
+			expected: true,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(string(testCase.resource), func(t *testing.T) {
+			got := isHostLevelResource(testCase.resource)
+			if got != testCase.expected {
+				t.Fatalf("expected %t to equal %t", got, testCase.expected)
+			}
+		})
+	}
+}

--- a/pkg/noderesourcetopology/numaresources_test.go
+++ b/pkg/noderesourcetopology/numaresources_test.go
@@ -361,7 +361,7 @@ func TestSubtractResourcesFromNUMANodeList(t *testing.T) {
 		t.Run(string(testCase.name), func(t *testing.T) {
 			nodes := testCase.nodes.DeepCopy()
 			logh := ktesting.NewLogger(t, ktesting.DefaultConfig)
-			err := subtractResourcesFromNUMANodeList(logh, nodes, testCase.numaID, testCase.qos, testCase.containerRes)
+			err := subtractResourcesFromNUMANodeList(logh, nodes, testCase.numaID, testCase.qos, testCase.containerRes, "test")
 			if (err != nil) != (testCase.expectedError != nil) {
 				t.Fatalf("got err %v expected err %v", err, testCase.expectedError)
 			}

--- a/pkg/noderesourcetopology/plugin.go
+++ b/pkg/noderesourcetopology/plugin.go
@@ -38,19 +38,6 @@ const (
 	Name = "NodeResourceTopologyMatch"
 )
 
-type NUMANode struct {
-	NUMAID    int
-	Resources v1.ResourceList
-	Costs     map[int]int
-}
-
-func (n *NUMANode) WithCosts(costs map[int]int) *NUMANode {
-	n.Costs = costs
-	return n
-}
-
-type NUMANodeList []NUMANode
-
 func subtractFromNUMAs(resources v1.ResourceList, numaNodes NUMANodeList, nodes ...int) {
 	for resName, quantity := range resources {
 		for _, node := range nodes {

--- a/test/integration/noderesourcetopology_test.go
+++ b/test/integration/noderesourcetopology_test.go
@@ -70,6 +70,8 @@ type nrtTestUserEntry struct {
 	cntReq      []map[string]string
 	errMsg      string
 	// this testing batch is going to be run against the same node and NRT objects, hence we're not specifying them.
+	isBurstable   bool
+	expectedNodes []string
 }
 
 type nrtTestEntry struct {
@@ -198,11 +200,12 @@ func TestTopologyMatchPlugin(t *testing.T) {
 
 	// Create a Node.
 	resList := map[v1.ResourceName]string{
-		v1.ResourceCPU:    "64",
-		v1.ResourceMemory: "128Gi",
-		v1.ResourcePods:   "32",
-		hugepages2Mi:      "896Mi",
-		nicResourceName:   "48",
+		v1.ResourceCPU:              "64",
+		v1.ResourceMemory:           "128Gi",
+		v1.ResourcePods:             "32",
+		hugepages2Mi:                "896Mi",
+		nicResourceName:             "48",
+		v1.ResourceEphemeralStorage: "32Gi",
 	}
 	for _, nodeName := range []string{"fake-node-1", "fake-node-2"} {
 		newNode := st.MakeNode().Name(nodeName).Label("node", nodeName).Capacity(resList).Obj()
@@ -1211,6 +1214,75 @@ func TestTopologyMatchPlugin(t *testing.T) {
 			},
 			errMsg: "cannot align init container", // initcnt-2
 		},
+		// ephemeral storage
+		{
+			description: "[tier1] single containers one requiring ephemeral storage with good allocation - fit",
+			cntReq: []map[string]string{
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "1Gi"},
+			},
+		},
+		{
+			description: "[tier1] multi containers all requiring ephemeral storage with good allocation - fit",
+			cntReq: []map[string]string{
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "1Gi"},
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "512Mi"},
+				{cpu: "4", memory: "8Gi", ephemeralStorage: "2Gi"},
+			},
+		},
+		{
+			description: "[tier1] multi containers some requiring ephemeral storage with good allocation - fit",
+			cntReq: []map[string]string{
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "1Gi"},
+				{cpu: "2", memory: "4Gi"},
+				{cpu: "4", memory: "8Gi", ephemeralStorage: "2Gi"},
+			},
+		},
+		{
+			description: "[tier1] multi containers one requiring ephemeral storage with good allocation - fit",
+			cntReq: []map[string]string{
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "1Gi"},
+				{cpu: "2", memory: "4Gi"},
+				{cpu: "4", memory: "8Gi"},
+			},
+		},
+		{
+			description: "[tier1][burstable] single containers one requiring ephemeral storage with good allocation - fit",
+			cntReq: []map[string]string{
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "1Gi"},
+			},
+			isBurstable:   true,
+			expectedNodes: []string{"fake-node-1", "fake-node-2"}, // any node
+		},
+		{
+			description: "[tier1][burstable] multi containers all requiring ephemeral storage with good allocation - fit",
+			cntReq: []map[string]string{
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "1Gi"},
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "512Mi"},
+				{cpu: "4", memory: "8Gi", ephemeralStorage: "2Gi"},
+			},
+			isBurstable:   true,
+			expectedNodes: []string{"fake-node-1", "fake-node-2"}, // any node
+		},
+		{
+			description: "[tier1][burstable] multi containers some requiring ephemeral storage with good allocation - fit",
+			cntReq: []map[string]string{
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "1Gi"},
+				{cpu: "2", memory: "4Gi"},
+				{cpu: "4", memory: "8Gi", ephemeralStorage: "2Gi"},
+			},
+			isBurstable:   true,
+			expectedNodes: []string{"fake-node-1", "fake-node-2"}, // any node
+		},
+		{
+			description: "[tier1][burstable] multi containers one requiring ephemeral storage with good allocation - fit",
+			cntReq: []map[string]string{
+				{cpu: "2", memory: "4Gi", ephemeralStorage: "1Gi"},
+				{cpu: "2", memory: "4Gi"},
+				{cpu: "4", memory: "8Gi"},
+			},
+			isBurstable:   true,
+			expectedNodes: []string{"fake-node-1", "fake-node-2"}, // any node
+		},
 	}
 	tests = append(tests, parseTestUserEntry(scopeEqualsContainerTests, ns)...)
 
@@ -1331,13 +1403,26 @@ func makeProfileByPluginArgs(
 func parseTestUserEntry(entries []nrtTestUserEntry, ns string) []nrtTestEntry {
 	var teList []nrtTestEntry
 	for i, e := range entries {
+		desiredQoS := v1.PodQOSGuaranteed
+		if e.isBurstable {
+			desiredQoS = v1.PodQOSBurstable
+		}
+
 		p := st.MakePod().Name(fmt.Sprintf("%s-%d", testPodName, i+1)).Namespace(ns)
 		for _, req := range e.initCntReq {
-			p = util.WithLimits(p, req, true)
+			if desiredQoS == v1.PodQOSGuaranteed {
+				p = util.WithLimits(p, req, true)
+			} else {
+				p = util.WithRequests(p, req, true)
+			}
 		}
 
 		for _, req := range e.cntReq {
-			p = util.WithLimits(p, req, false)
+			if desiredQoS == v1.PodQOSGuaranteed {
+				p = util.WithLimits(p, req, false)
+			} else {
+				p = util.WithRequests(p, req, false)
+			}
 		}
 		nodeTopologies := []*topologyv1alpha2.NodeResourceTopology{
 			MakeNRT().Name("fake-node-1").Policy(topologyv1alpha2.SingleNUMANodeContainerLevel).
@@ -1373,9 +1458,11 @@ func parseTestUserEntry(entries []nrtTestUserEntry, ns string) []nrtTestEntry {
 					}).Obj(),
 		}
 		expectedNodes := []string{"fake-node-1"}
-		// if there's an error we expect the pod
-		// to not be found on any node
-		if len(e.errMsg) > 0 {
+		if len(e.expectedNodes) > 0 {
+			expectedNodes = e.expectedNodes
+		} else if len(e.errMsg) > 0 {
+			// if there's an error we expect the pod
+			// to not be found on any node
 			expectedNodes = []string{}
 		}
 		te := nrtTestEntry{

--- a/test/integration/nrtutils.go
+++ b/test/integration/nrtutils.go
@@ -40,10 +40,12 @@ import (
 )
 
 const (
-	cpu             = string(corev1.ResourceCPU)
-	memory          = string(corev1.ResourceMemory)
-	hugepages2Mi    = "hugepages-2Mi"
-	nicResourceName = "vendor/nic1"
+	cpu              = string(corev1.ResourceCPU)
+	memory           = string(corev1.ResourceMemory)
+	gpuResourceName  = "vendor/gpu"
+	hugepages2Mi     = "hugepages-2Mi"
+	nicResourceName  = "vendor/nic1"
+	ephemeralStorage = string(corev1.ResourceEphemeralStorage)
 )
 
 func waitForNRT(cs *kubernetes.Clientset) error {

--- a/vendor/k8s.io/klog/v2/internal/verbosity/verbosity.go
+++ b/vendor/k8s.io/klog/v2/internal/verbosity/verbosity.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2013 Google Inc. All Rights Reserved.
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package verbosity
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// New returns a struct that implements -v and -vmodule support. Changing and
+// checking these settings is thread-safe, with all concurrency issues handled
+// internally.
+func New() *VState {
+	vs := new(VState)
+
+	// The two fields must have a pointer to the overal struct for their
+	// implementation of Set.
+	vs.vmodule.vs = vs
+	vs.verbosity.vs = vs
+
+	return vs
+}
+
+// Value is an extension that makes it possible to use the values in pflag.
+type Value interface {
+	flag.Value
+	Type() string
+}
+
+func (vs *VState) V() Value {
+	return &vs.verbosity
+}
+
+func (vs *VState) VModule() Value {
+	return &vs.vmodule
+}
+
+// VState contains settings and state. Some of its fields can be accessed
+// through atomic read/writes, in other cases a mutex must be held.
+type VState struct {
+	mu sync.Mutex
+
+	// These flags are modified only under lock, although verbosity may be fetched
+	// safely using atomic.LoadInt32.
+	vmodule   moduleSpec // The state of the -vmodule flag.
+	verbosity levelSpec  // V logging level, the value of the -v flag/
+
+	// pcs is used in V to avoid an allocation when computing the caller's PC.
+	pcs [1]uintptr
+	// vmap is a cache of the V Level for each V() call site, identified by PC.
+	// It is wiped whenever the vmodule flag changes state.
+	vmap map[uintptr]Level
+	// filterLength stores the length of the vmodule filter chain. If greater
+	// than zero, it means vmodule is enabled. It may be read safely
+	// using sync.LoadInt32, but is only modified under mu.
+	filterLength int32
+}
+
+// Level must be an int32 to support atomic read/writes.
+type Level int32
+
+type levelSpec struct {
+	vs *VState
+	l  Level
+}
+
+// get returns the value of the level.
+func (l *levelSpec) get() Level {
+	return Level(atomic.LoadInt32((*int32)(&l.l)))
+}
+
+// set sets the value of the level.
+func (l *levelSpec) set(val Level) {
+	atomic.StoreInt32((*int32)(&l.l), int32(val))
+}
+
+// String is part of the flag.Value interface.
+func (l *levelSpec) String() string {
+	return strconv.FormatInt(int64(l.l), 10)
+}
+
+// Get is part of the flag.Getter interface. It returns the
+// verbosity level as int32.
+func (l *levelSpec) Get() interface{} {
+	return int32(l.l)
+}
+
+// Type is part of pflag.Value.
+func (l *levelSpec) Type() string {
+	return "Level"
+}
+
+// Set is part of the flag.Value interface.
+func (l *levelSpec) Set(value string) error {
+	v, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return err
+	}
+	l.vs.mu.Lock()
+	defer l.vs.mu.Unlock()
+	l.vs.set(Level(v), l.vs.vmodule.filter, false)
+	return nil
+}
+
+// moduleSpec represents the setting of the -vmodule flag.
+type moduleSpec struct {
+	vs     *VState
+	filter []modulePat
+}
+
+// modulePat contains a filter for the -vmodule flag.
+// It holds a verbosity level and a file pattern to match.
+type modulePat struct {
+	pattern string
+	literal bool // The pattern is a literal string
+	level   Level
+}
+
+// match reports whether the file matches the pattern. It uses a string
+// comparison if the pattern contains no metacharacters.
+func (m *modulePat) match(file string) bool {
+	if m.literal {
+		return file == m.pattern
+	}
+	match, _ := filepath.Match(m.pattern, file)
+	return match
+}
+
+func (m *moduleSpec) String() string {
+	// Lock because the type is not atomic. TODO: clean this up.
+	// Empty instances don't have and don't need a lock (can
+	// happen when flag uses introspection).
+	if m.vs != nil {
+		m.vs.mu.Lock()
+		defer m.vs.mu.Unlock()
+	}
+	var b bytes.Buffer
+	for i, f := range m.filter {
+		if i > 0 {
+			b.WriteRune(',')
+		}
+		fmt.Fprintf(&b, "%s=%d", f.pattern, f.level)
+	}
+	return b.String()
+}
+
+// Get is part of the (Go 1.2)  flag.Getter interface. It always returns nil for this flag type since the
+// struct is not exported.
+func (m *moduleSpec) Get() interface{} {
+	return nil
+}
+
+// Type is part of pflag.Value
+func (m *moduleSpec) Type() string {
+	return "pattern=N,..."
+}
+
+var errVmoduleSyntax = errors.New("syntax error: expect comma-separated list of filename=N")
+
+// Set will sets module value
+// Syntax: -vmodule=recordio=2,file=1,gfs*=3
+func (m *moduleSpec) Set(value string) error {
+	var filter []modulePat
+	for _, pat := range strings.Split(value, ",") {
+		if len(pat) == 0 {
+			// Empty strings such as from a trailing comma can be ignored.
+			continue
+		}
+		patLev := strings.Split(pat, "=")
+		if len(patLev) != 2 || len(patLev[0]) == 0 || len(patLev[1]) == 0 {
+			return errVmoduleSyntax
+		}
+		pattern := patLev[0]
+		v, err := strconv.ParseInt(patLev[1], 10, 32)
+		if err != nil {
+			return errors.New("syntax error: expect comma-separated list of filename=N")
+		}
+		if v < 0 {
+			return errors.New("negative value for vmodule level")
+		}
+		if v == 0 {
+			continue // Ignore. It's harmless but no point in paying the overhead.
+		}
+		// TODO: check syntax of filter?
+		filter = append(filter, modulePat{pattern, isLiteral(pattern), Level(v)})
+	}
+	m.vs.mu.Lock()
+	defer m.vs.mu.Unlock()
+	m.vs.set(m.vs.verbosity.l, filter, true)
+	return nil
+}
+
+// isLiteral reports whether the pattern is a literal string, that is, has no metacharacters
+// that require filepath.Match to be called to match the pattern.
+func isLiteral(pattern string) bool {
+	return !strings.ContainsAny(pattern, `\*?[]`)
+}
+
+// set sets a consistent state for V logging.
+// The mutex must be held.
+func (vs *VState) set(l Level, filter []modulePat, setFilter bool) {
+	// Turn verbosity off so V will not fire while we are in transition.
+	vs.verbosity.set(0)
+	// Ditto for filter length.
+	atomic.StoreInt32(&vs.filterLength, 0)
+
+	// Set the new filters and wipe the pc->Level map if the filter has changed.
+	if setFilter {
+		vs.vmodule.filter = filter
+		vs.vmap = make(map[uintptr]Level)
+	}
+
+	// Things are consistent now, so enable filtering and verbosity.
+	// They are enabled in order opposite to that in V.
+	atomic.StoreInt32(&vs.filterLength, int32(len(filter)))
+	vs.verbosity.set(l)
+}
+
+// Enabled checks whether logging is enabled at the given level. This must be
+// called with depth=0 when the caller of enabled will do the logging and
+// higher values when more stack levels need to be skipped.
+//
+// The mutex will be locked only if needed.
+func (vs *VState) Enabled(level Level, depth int) bool {
+	// This function tries hard to be cheap unless there's work to do.
+	// The fast path is two atomic loads and compares.
+
+	// Here is a cheap but safe test to see if V logging is enabled globally.
+	if vs.verbosity.get() >= level {
+		return true
+	}
+
+	// It's off globally but vmodule may still be set.
+	// Here is another cheap but safe test to see if vmodule is enabled.
+	if atomic.LoadInt32(&vs.filterLength) > 0 {
+		// Now we need a proper lock to use the logging structure. The pcs field
+		// is shared so we must lock before accessing it. This is fairly expensive,
+		// but if V logging is enabled we're slow anyway.
+		vs.mu.Lock()
+		defer vs.mu.Unlock()
+		if runtime.Callers(depth+2, vs.pcs[:]) == 0 {
+			return false
+		}
+		// runtime.Callers returns "return PCs", but we want
+		// to look up the symbolic information for the call,
+		// so subtract 1 from the PC. runtime.CallersFrames
+		// would be cleaner, but allocates.
+		pc := vs.pcs[0] - 1
+		v, ok := vs.vmap[pc]
+		if !ok {
+			v = vs.setV(pc)
+		}
+		return v >= level
+	}
+	return false
+}
+
+// setV computes and remembers the V level for a given PC
+// when vmodule is enabled.
+// File pattern matching takes the basename of the file, stripped
+// of its .go suffix, and uses filepath.Match, which is a little more
+// general than the *? matching used in C++.
+// Mutex is held.
+func (vs *VState) setV(pc uintptr) Level {
+	fn := runtime.FuncForPC(pc)
+	file, _ := fn.FileLine(pc)
+	// The file is something like /a/b/c/d.go. We want just the d.
+	if strings.HasSuffix(file, ".go") {
+		file = file[:len(file)-3]
+	}
+	if slash := strings.LastIndex(file, "/"); slash >= 0 {
+		file = file[slash+1:]
+	}
+	for _, filter := range vs.vmodule.filter {
+		if filter.match(file) {
+			vs.vmap[pc] = filter.level
+			return filter.level
+		}
+	}
+	vs.vmap[pc] = 0
+	return 0
+}

--- a/vendor/k8s.io/klog/v2/ktesting/options.go
+++ b/vendor/k8s.io/klog/v2/ktesting/options.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"flag"
+	"strconv"
+
+	"k8s.io/klog/v2/internal/verbosity"
+)
+
+// Config influences logging in a test logger. To make this configurable via
+// command line flags, instantiate this once per program and use AddFlags to
+// bind command line flags to the instance before passing it to NewTestContext.
+//
+// Must be constructed with NewConfig.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type Config struct {
+	vstate *verbosity.VState
+	co     configOptions
+}
+
+// ConfigOption implements functional parameters for NewConfig.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type ConfigOption func(co *configOptions)
+
+type configOptions struct {
+	verbosityFlagName string
+	vmoduleFlagName   string
+	verbosityDefault  int
+}
+
+// VerbosityFlagName overrides the default -testing.v for the verbosity level.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func VerbosityFlagName(name string) ConfigOption {
+	return func(co *configOptions) {
+		co.verbosityFlagName = name
+	}
+}
+
+// VModulFlagName overrides the default -testing.vmodule for the per-module
+// verbosity levels.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func VModuleFlagName(name string) ConfigOption {
+	return func(co *configOptions) {
+		co.vmoduleFlagName = name
+	}
+}
+
+// Verbosity overrides the default verbosity level of 5. That default is higher
+// than in klog itself because it enables logging entries for "the steps
+// leading up to errors and warnings" and "troubleshooting" (see
+// https://github.com/kubernetes/community/blob/9406b4352fe2d5810cb21cc3cb059ce5886de157/contributors/devel/sig-instrumentation/logging.md#logging-conventions),
+// which is useful when debugging a failed test. `go test` only shows the log
+// output for failed tests. To see all output, use `go test -v`.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func Verbosity(level int) ConfigOption {
+	return func(co *configOptions) {
+		co.verbosityDefault = level
+	}
+}
+
+// NewConfig returns a configuration with recommended defaults and optional
+// modifications. Command line flags are not bound to any FlagSet yet.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewConfig(opts ...ConfigOption) *Config {
+	c := &Config{
+		co: configOptions{
+			verbosityFlagName: "testing.v",
+			vmoduleFlagName:   "testing.vmodule",
+			verbosityDefault:  5,
+		},
+	}
+	for _, opt := range opts {
+		opt(&c.co)
+	}
+
+	c.vstate = verbosity.New()
+	c.vstate.V().Set(strconv.FormatInt(int64(c.co.verbosityDefault), 10))
+	return c
+}
+
+// AddFlags registers the command line flags that control the configuration.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func (c *Config) AddFlags(fs *flag.FlagSet) {
+	fs.Var(c.vstate.V(), c.co.verbosityFlagName, "number for the log level verbosity of the testing logger")
+	fs.Var(c.vstate.VModule(), c.co.vmoduleFlagName, "comma-separated list of pattern=N log level settings for files matching the patterns")
+}

--- a/vendor/k8s.io/klog/v2/ktesting/setup.go
+++ b/vendor/k8s.io/klog/v2/ktesting/setup.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ktesting
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+// DefaultConfig is the global default logging configuration for a unit
+// test. It is used by NewTestContext and k8s.io/klogr/testing/init.
+//
+// Experimental
+//
+// Notice: This variable is EXPERIMENTAL and may be changed or removed in a
+// later release.
+var DefaultConfig = NewConfig()
+
+// NewTestContext returns a logger and context for use in a unit test case or
+// benchmark. The tl parameter can be a testing.T or testing.B pointer that
+// will receive all log output. Importing k8s.io/klogr/testing/init will add
+// command line flags that modify the configuration of that log output.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewTestContext(tl TL) (logr.Logger, context.Context) {
+	logger := NewLogger(tl, DefaultConfig)
+	ctx := logr.NewContext(context.Background(), logger)
+	return logger, ctx
+
+}

--- a/vendor/k8s.io/klog/v2/ktesting/testinglogger.go
+++ b/vendor/k8s.io/klog/v2/ktesting/testinglogger.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testinglogger contains an implementation of the logr interface
+// which is logging through a function like testing.TB.Log function.
+// Therefore it can be used in standard Go tests and Gingko test suites
+// to ensure that output is associated with the currently running test.
+//
+// In addition, the log data is captured in a buffer and can be used by the
+// test to verify that the code under test is logging as expected. To get
+// access to that data, cast the LogSink into the Underlier type and retrieve
+// it:
+//
+//    logger := ktesting.NewLogger(...)
+//    if testingLogger, ok := logger.GetSink().(ktesting.Underlier); ok {
+//        t := testingLogger.GetUnderlying()
+//        buffer := testingLogger.GetBuffer()
+//        text := buffer.String()
+//        log := buffer.Data()
+//
+// Serialization of the structured log parameters is done in the same way
+// as for klog.InfoS.
+//
+// Experimental
+//
+// Notice: This package is EXPERIMENTAL and may be changed or removed in a
+// later release.
+package ktesting
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/internal/dbg"
+	"k8s.io/klog/v2/internal/serialize"
+	"k8s.io/klog/v2/internal/verbosity"
+)
+
+// TL is the relevant subset of testing.TB.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type TL interface {
+	Helper()
+	Log(args ...interface{})
+}
+
+// NopTL implements TL with empty stubs. It can be used when only capturing
+// output in memory is relevant.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type NopTL struct{}
+
+func (n NopTL) Helper()                 {}
+func (n NopTL) Log(args ...interface{}) {}
+
+var _ TL = NopTL{}
+
+// NewLogger constructs a new logger for the given test interface.
+//
+// Beware that testing.T does not support logging after the test that
+// it was created for has completed. If a test leaks goroutines
+// and those goroutines log something after test completion,
+// that output will be printed via the global klog logger with
+// `<test name> leaked goroutine` as prefix.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func NewLogger(t TL, c *Config) logr.Logger {
+	l := tlogger{
+		shared: &tloggerShared{
+			t:      t,
+			config: c,
+		},
+	}
+
+	type testCleanup interface {
+		Cleanup(func())
+		Name() string
+	}
+
+	// Stopping the logging is optional and only done (and required)
+	// for testing.T/B/F.
+	if tb, ok := t.(testCleanup); ok {
+		tb.Cleanup(l.shared.stop)
+		l.shared.testName = tb.Name()
+	}
+	return logr.New(l)
+}
+
+// Buffer stores log entries as formatted text and structured data.
+// It is safe to use this concurrently.
+//
+// Experimental
+//
+// Notice: This interface is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type Buffer interface {
+	// String returns the log entries in a format that is similar to the
+	// klog text output.
+	String() string
+
+	// Data returns the log entries as structs.
+	Data() Log
+}
+
+// Log contains log entries in the order in which they were generated.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type Log []LogEntry
+
+// DeepCopy returns a copy of the log. The error instance and key/value
+// pairs remain shared.
+//
+// Experimental
+//
+// Notice: This function is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func (l Log) DeepCopy() Log {
+	log := make(Log, 0, len(l))
+	log = append(log, l...)
+	return log
+}
+
+// LogEntry represents all information captured for a log entry.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type LogEntry struct {
+	// Timestamp stores the time when the log entry was created.
+	Timestamp time.Time
+
+	// Type is either LogInfo or LogError.
+	Type LogType
+
+	// Prefix contains the WithName strings concatenated with a slash.
+	Prefix string
+
+	// Message is the fixed log message string.
+	Message string
+
+	// Verbosity is always 0 for LogError.
+	Verbosity int
+
+	// Err is always nil for LogInfo. It may or may not be
+	// nil for LogError.
+	Err error
+
+	// WithKVList are the concatenated key/value pairs from WithValues
+	// calls. It's guaranteed to have an even number of entries because
+	// the logger ensures that when WithValues is called.
+	WithKVList []interface{}
+
+	// ParameterKVList are the key/value pairs passed into the call,
+	// without any validation.
+	ParameterKVList []interface{}
+}
+
+// LogType determines whether a log entry was created with an Error or Info
+// call.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type LogType string
+
+const (
+	// LogError is the special value used for Error log entries.
+	//
+	// Experimental
+	//
+	// Notice: This value is EXPERIMENTAL and may be changed or removed in
+	// a later release.
+	LogError = LogType("ERROR")
+
+	// LogInfo is the special value used for Info log entries.
+	//
+	// Experimental
+	//
+	// Notice: This value is EXPERIMENTAL and may be changed or removed in
+	// a later release.
+	LogInfo = LogType("INFO")
+)
+
+// Underlier is implemented by the LogSink of this logger. It provides access
+// to additional APIs that are normally hidden behind the Logger API.
+//
+// Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type Underlier interface {
+	// GetUnderlying returns the testing instance that logging goes to.
+	// It returns nil when the test has completed already.
+	GetUnderlying() TL
+
+	// GetBuffer grants access to the in-memory copy of the log entries.
+	GetBuffer() Buffer
+}
+
+type buffer struct {
+	mutex sync.Mutex
+	text  strings.Builder
+	log   Log
+}
+
+func (b *buffer) String() string {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return b.text.String()
+}
+
+func (b *buffer) Data() Log {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return b.log.DeepCopy()
+}
+
+// tloggerShared holds values that are the same for all LogSink instances. It
+// gets referenced by pointer in the tlogger struct.
+type tloggerShared struct {
+	// mutex protects access to t.
+	mutex sync.Mutex
+
+	// t gets cleared when the test is completed.
+	t TL
+
+	// We warn once when a leaked goroutine is detected because
+	// it logs after test completion.
+	goroutineWarningDone bool
+
+	testName  string
+	config    *Config
+	buffer    buffer
+	callDepth int
+}
+
+func (ls *tloggerShared) stop() {
+	ls.mutex.Lock()
+	defer ls.mutex.Unlock()
+	ls.t = nil
+}
+
+// tlogger is the actual LogSink implementation.
+type tlogger struct {
+	shared *tloggerShared
+	prefix string
+	values []interface{}
+}
+
+func (l tlogger) fallbackLogger() logr.Logger {
+	logger := klog.Background().WithValues(l.values...).WithName(l.shared.testName + " leaked goroutine")
+	if l.prefix != "" {
+		logger = logger.WithName(l.prefix)
+	}
+	// Skip direct caller (= Error or Info) plus the logr wrapper.
+	logger = logger.WithCallDepth(l.shared.callDepth + 1)
+
+	if !l.shared.goroutineWarningDone {
+		logger.WithCallDepth(1).Error(nil, "WARNING: test kept at least one goroutine running after test completion", "callstack", string(dbg.Stacks(false)))
+		l.shared.goroutineWarningDone = true
+	}
+	return logger
+}
+
+func (l tlogger) Init(info logr.RuntimeInfo) {
+	l.shared.callDepth = info.CallDepth
+}
+
+func (l tlogger) GetCallStackHelper() func() {
+	l.shared.mutex.Lock()
+	defer l.shared.mutex.Unlock()
+	if l.shared.t == nil {
+		return func() {}
+	}
+
+	return l.shared.t.Helper
+}
+
+func (l tlogger) Info(level int, msg string, kvList ...interface{}) {
+	l.shared.mutex.Lock()
+	defer l.shared.mutex.Unlock()
+	if l.shared.t == nil {
+		l.fallbackLogger().V(level).Info(msg, kvList...)
+		return
+	}
+
+	l.shared.t.Helper()
+	buffer := &bytes.Buffer{}
+	merged := serialize.MergeKVs(l.values, kvList)
+	serialize.KVListFormat(buffer, merged...)
+	l.log(LogInfo, msg, level, buffer, nil, kvList)
+}
+
+func (l tlogger) Enabled(level int) bool {
+	return l.shared.config.vstate.Enabled(verbosity.Level(level), 1)
+}
+
+func (l tlogger) Error(err error, msg string, kvList ...interface{}) {
+	l.shared.mutex.Lock()
+	defer l.shared.mutex.Unlock()
+	if l.shared.t == nil {
+		l.fallbackLogger().Error(err, msg, kvList...)
+		return
+	}
+
+	l.shared.t.Helper()
+	buffer := &bytes.Buffer{}
+	if err != nil {
+		serialize.KVListFormat(buffer, "err", err)
+	}
+	merged := serialize.MergeKVs(l.values, kvList)
+	serialize.KVListFormat(buffer, merged...)
+	l.log(LogError, msg, 0, buffer, err, kvList)
+}
+
+func (l tlogger) log(what LogType, msg string, level int, buffer *bytes.Buffer, err error, kvList []interface{}) {
+	l.shared.t.Helper()
+	args := []interface{}{what}
+	if l.prefix != "" {
+		args = append(args, l.prefix+":")
+	}
+	args = append(args, msg)
+	if buffer.Len() > 0 {
+		// Skip leading space inserted by serialize.KVListFormat.
+		args = append(args, string(buffer.Bytes()[1:]))
+	}
+	l.shared.t.Log(args...)
+
+	l.shared.buffer.mutex.Lock()
+	defer l.shared.buffer.mutex.Unlock()
+
+	// Store as text.
+	l.shared.buffer.text.WriteString(string(what))
+	for i := 1; i < len(args); i++ {
+		l.shared.buffer.text.WriteByte(' ')
+		l.shared.buffer.text.WriteString(args[i].(string))
+	}
+	lastArg := args[len(args)-1].(string)
+	if lastArg[len(lastArg)-1] != '\n' {
+		l.shared.buffer.text.WriteByte('\n')
+	}
+
+	// Store as raw data.
+	l.shared.buffer.log = append(l.shared.buffer.log,
+		LogEntry{
+			Timestamp:       time.Now(),
+			Type:            what,
+			Prefix:          l.prefix,
+			Message:         msg,
+			Verbosity:       level,
+			Err:             err,
+			WithKVList:      l.values,
+			ParameterKVList: kvList,
+		},
+	)
+}
+
+// WithName returns a new logr.Logger with the specified name appended.  klogr
+// uses '/' characters to separate name elements.  Callers should not pass '/'
+// in the provided name string, but this library does not actually enforce that.
+func (l tlogger) WithName(name string) logr.LogSink {
+	if len(l.prefix) > 0 {
+		l.prefix = l.prefix + "/"
+	}
+	l.prefix += name
+	return l
+}
+
+func (l tlogger) WithValues(kvList ...interface{}) logr.LogSink {
+	l.values = serialize.WithValues(l.values, kvList)
+	return l
+}
+
+func (l tlogger) GetUnderlying() TL {
+	return l.shared.t
+}
+
+func (l tlogger) GetBuffer() Buffer {
+	return &l.shared.buffer
+}
+
+var _ logr.LogSink = &tlogger{}
+var _ logr.CallStackHelperLogSink = &tlogger{}
+var _ Underlier = &tlogger{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1234,7 +1234,9 @@ k8s.io/klog/v2/internal/clock
 k8s.io/klog/v2/internal/dbg
 k8s.io/klog/v2/internal/serialize
 k8s.io/klog/v2/internal/severity
+k8s.io/klog/v2/internal/verbosity
 k8s.io/klog/v2/klogr
+k8s.io/klog/v2/ktesting
 # k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1
 ## explicit; go 1.18
 k8s.io/kube-openapi/cmd/openapi-gen/args


### PR DESCRIPTION
resync to consume fixes to ephemeral storage

add API fixes because the cherry-picked commits where made against a much modern codebase (and k8s libs)
