### PR TITLE
[KNI][release-4.13][manual] improve klogr compatibility

### DIFF
--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -78,7 +78,7 @@ func singleNUMAContainerLevelHandler(pod *v1.Pod, zones topologyv1alpha2.ZoneLis
 
 		// subtract the resources requested by the container from the given NUMA.
 		// this is necessary, so we won't allocate the same resources for the upcoming containers
-		clh := klogr.New().WithValues("logID", logID, "node", nodeInfo.Node().Name)
+		clh := klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)).WithValues("logID", logID, "node", nodeInfo.Node().Name)
 		err := subtractResourcesFromNUMANodeList(clh, nodes, numaID, qos, container.Resources.Requests, logID)
 		if err != nil {
 			// this is an internal error which should never happen


### PR DESCRIPTION
the klogr wrapper should not serialize args but rather pass them through, because this is the behavior most similar to what we will have in 4.16 and onwards.

Signed-off-by: Francesco Romani <fromani@redhat.com>
(cherry picked from commit ad71d2056ae67db27a217d5f2bbfca450eb427a7)
