### PR TITLE
[KNI][release-4.14] score: fix logging of found NRT objects

### DIFF
--- a/pkg/noderesourcetopology/logging.go
+++ b/pkg/noderesourcetopology/logging.go
@@ -17,12 +17,9 @@ limitations under the License.
 package noderesourcetopology
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"k8s.io/klog/v2"
-
-	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
 
 	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/stringify"
 )
@@ -32,18 +29,4 @@ func logNumaNodes(desc, nodeName string, nodes NUMANodeList) {
 		numaLogKey := fmt.Sprintf("%s/node-%d", nodeName, numaNode.NUMAID)
 		klog.V(6).InfoS(desc, stringify.ResourceListToLoggable(numaLogKey, numaNode.Resources)...)
 	}
-}
-
-func logNRT(desc string, nrtObj *topologyv1alpha2.NodeResourceTopology) {
-	if !klog.V(6).Enabled() {
-		// avoid the expensive marshal operation
-		return
-	}
-
-	ntrJson, err := json.MarshalIndent(nrtObj, "", " ")
-	if err != nil {
-		klog.V(6).ErrorS(err, "failed to marshal noderesourcetopology object")
-		return
-	}
-	klog.V(6).Info(desc, "noderesourcetopology", string(ntrJson))
 }

--- a/pkg/noderesourcetopology/score.go
+++ b/pkg/noderesourcetopology/score.go
@@ -30,6 +30,7 @@ import (
 	apiconfig "sigs.k8s.io/scheduler-plugins/apis/config"
 
 	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/stringify"
 	"sigs.k8s.io/scheduler-plugins/pkg/util"
 )
 
@@ -74,7 +75,7 @@ func (tm *TopologyMatch) Score(ctx context.Context, state *framework.CycleState,
 		return 0, nil
 	}
 
-	logNRT("noderesourcetopology found", nodeTopology)
+	klog.V(6).Info("found object", "noderesourcetopology", stringify.NodeResourceTopologyResources(nodeTopology))
 
 	handler := tm.scoringHandlerFromTopologyManagerConfig(topologyManagerConfigFromNodeResourceTopology(nodeTopology))
 	if handler == nil {


### PR DESCRIPTION
make the log more concise, yet don't trim the
amount of information logged.

extracted from: k/k/sigs/scheduler-plugins@045a43d184735d67d302c55a8d04b13ed928efcc
