### PR TITLE
[KNI][release-4.18] snyk: update ignore list

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -16,6 +16,7 @@ exclude:
     - vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go
     - vendor/github.com/google/uuid/hash.go
     - vendor/github.com/paypal/load-watcher/pkg/watcher/internal/metricsprovider/prometheus.go
+    - vendor/github.com/spf13/cobra/command.go
     - vendor/golang.org/x/net/websocket/hybi.go
     - vendor/golang.org/x/tools/go/analysis/unitchecker/unitchecker.go
     - vendor/golang.org/x/tools/internal/pkgbits/encoder.go


### PR DESCRIPTION
The linter is now complaining about an old dep,
for the time being (and likely for the mid term)
we will ignore the warning. cobra is an indirect dep anyway.

Signed-off-by: Francesco Romani <fromani@redhat.com>
(cherry picked from commit 68523f6f46381645d937296b4abf644ed7bfbddf)
