### PR TITLE
[KNI] ci: ghactions: ensure golang version in vendor check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,5 +61,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.23
+
       - name: Verify vendoring
         run: ./hack-kni/verify-vendoring.sh

--- a/hack-kni/verify-vendoring.sh
+++ b/hack-kni/verify-vendoring.sh
@@ -23,6 +23,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${SCRIPT_ROOT}"
 
+go version
 go mod vendor
 if [[ $? -ne 0  ]]; then
   echo echo 'Command "go mod vendor" failed' >&2


### PR DESCRIPTION
make sure we run the vendor check in a controlled environment, and also make sure to emit the golang version we use.
