### PR TITLE
[KNI][release-4.12] ci: ghactions: ensure golang version in vendor check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,5 +35,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.5
+
       - name: Verify vendoring
         run: ./hack-kni/verify-vendoring.sh

--- a/hack-kni/verify-vendoring.sh
+++ b/hack-kni/verify-vendoring.sh
@@ -23,6 +23,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${SCRIPT_ROOT}"
 
+go version
 go mod vendor
 if [[ $? -ne 0  ]]; then
   echo echo 'Command "go mod vendor" failed' >&2


### PR DESCRIPTION
make sure we run the vendor check in a controlled environment, and also make sure to emit the golang version we use.

Signed-off-by: Francesco Romani <fromani@redhat.com>
(cherry picked from commit 2f4974a6fa5f752e21ad8680cbc8b2550d53958e)
