### PR TITLE
[KNI][release-4.18] snyk: exclude more files

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -19,5 +19,5 @@ exclude:
     - vendor/github.com/spf13/cobra/command.go
     - vendor/golang.org/x/net/websocket/hybi.go
     - vendor/golang.org/x/tools/go/analysis/unitchecker/unitchecker.go
-    - vendor/golang.org/x/tools/internal/pkgbits/encoder.go
+    - vendor/golang.org/x/tools/internal/**
     - vendor/go.etcd.io/etcd/client/pkg/v3/transport/listener.go


### PR DESCRIPTION
we trust golang.org/x/tools

Signed-off-by: Francesco Romani <fromani@redhat.com>
(cherry picked from commit 563a21825bc18d1707211546f39f4d95380ac8c0)
