### PR TITLE
[KNI][release-4.17] fix go.mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/scheduler-plugins
 
-go 1.21
+go 1.22
 
 require (
 	github.com/containers/common v0.60.4

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testdata/a/foo.txt
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testdata/a/foo.txt
@@ -1,1 +1,0 @@
-Hello World


### PR DESCRIPTION
we build with go 1.22, we can bump the minimum version