### PR TITLE
[KNI] bump golang version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/scheduler-plugins
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/containers/common v0.60.4


### PR DESCRIPTION
we are a top-level package, so we can require a more recent version wrt our deps, until the go 1 backward promise is respected. This will help with next dep bumps.

We build already with golang 1.23 anyway
