### PR TITLE
[KNI] add helpers to patch objects with legacy data

### DIFF
--- a/hack-kni/legacy/README.md
+++ b/hack-kni/legacy/README.md
@@ -1,0 +1,20 @@
+# nrtpatch
+
+use this tool to automatically set the deprecated `topologyPolicies` field with a value consistent with the content of the NRT object attributes.
+This is effectively a wasteful no-operation which can be needed in corner cases scenarios.
+
+assuming a valid KUBECONFIG
+check the computed value:
+```
+kubectl get noderesourcetopologies.topology.node.k8s.io node19.lab.example.com -o json | go run ./nrtpatch.go
+```
+
+automatically patch the relevant object:
+```
+eval $( kubectl get noderesourcetopologies.topology.node.k8s.io node19.lab.example.com -o json | go run ./nrtpatch.go )
+```
+
+undo the changes:
+```
+kubectl patch noderesourcetopologies.topology.node.k8s.io node19.lab.example.com --type=merge -p {"topologyPolicies":[]}
+```

--- a/hack-kni/legacy/example.json
+++ b/hack-kni/legacy/example.json
@@ -1,0 +1,103 @@
+{
+    "apiVersion": "topology.node.k8s.io/v1alpha2",
+    "attributes": [
+        {
+            "name": "nodeTopologyPodsFingerprint",
+            "value": "pfp0v001ad69e4281990b17e"
+        },
+        {
+            "name": "nodeTopologyPodsFingerprintMethod",
+            "value": "with-exclusive-resources"
+        },
+        {
+            "name": "topologyManagerScope",
+            "value": "container"
+        },
+        {
+            "name": "topologyManagerPolicy",
+            "value": "single-numa-node"
+        }
+    ],
+    "kind": "NodeResourceTopology",
+    "metadata": {
+        "annotations": {
+            "k8stopoawareschedwg/rte-update": "periodic",
+            "topology.node.k8s.io/fingerprint": "pfp0v001ad69e4281990b17e"
+        },
+        "creationTimestamp": "2025-02-04T08:21:30Z",
+        "generation": 316123,
+        "name": "node19.lab.example.com",
+        "resourceVersion": "49267399",
+        "uid": "b40b13d9-89f3-4c9e-958d-72cae30146dd"
+    },
+    "zones": [
+        {
+            "costs": [
+                {
+                    "name": "node-0",
+                    "value": 10
+                },
+                {
+                    "name": "node-1",
+                    "value": 21
+                }
+            ],
+            "name": "node-0",
+            "resources": [
+                {
+                    "allocatable": "8589934592",
+                    "available": "8589934592",
+                    "capacity": "8589934592",
+                    "name": "hugepages-1Gi"
+                },
+                {
+                    "allocatable": "39409012736",
+                    "available": "38603706368",
+                    "capacity": "49152380928",
+                    "name": "memory"
+                },
+                {
+                    "allocatable": "50",
+                    "available": "47",
+                    "capacity": "52",
+                    "name": "cpu"
+                }
+            ],
+            "type": "Node"
+        },
+        {
+            "costs": [
+                {
+                    "name": "node-0",
+                    "value": 21
+                },
+                {
+                    "name": "node-1",
+                    "value": 10
+                }
+            ],
+            "name": "node-1",
+            "resources": [
+                {
+                    "allocatable": "50",
+                    "available": "50",
+                    "capacity": "52",
+                    "name": "cpu"
+                },
+                {
+                    "allocatable": "8589934592",
+                    "available": "8589934592",
+                    "capacity": "8589934592",
+                    "name": "hugepages-1Gi"
+                },
+                {
+                    "allocatable": "42126929920",
+                    "available": "42126929920",
+                    "capacity": "50716864512",
+                    "name": "memory"
+                }
+            ],
+            "type": "Node"
+        }
+    ]
+}

--- a/hack-kni/legacy/nrtpatch.go
+++ b/hack-kni/legacy/nrtpatch.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+
+	topologyv1alpha2 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"sigs.k8s.io/scheduler-plugins/pkg/noderesourcetopology/nodeconfig"
+)
+
+func toTopologyManagerPolicy(conf nodeconfig.TopologyManager) string {
+	if conf.Policy == kubeletconfig.SingleNumaNodeTopologyManagerPolicy && conf.Scope == kubeletconfig.PodTopologyManagerScope {
+		return string(topologyv1alpha2.SingleNUMANodePodLevel)
+	}
+	if conf.Policy == kubeletconfig.SingleNumaNodeTopologyManagerPolicy && conf.Scope == kubeletconfig.ContainerTopologyManagerScope {
+		return string(topologyv1alpha2.SingleNUMANodeContainerLevel)
+	}
+	if conf.Policy == kubeletconfig.BestEffortTopologyManagerPolicy && conf.Scope == kubeletconfig.PodTopologyManagerScope {
+		return string(topologyv1alpha2.BestEffortPodLevel)
+	}
+	if conf.Policy == kubeletconfig.BestEffortTopologyManagerPolicy && conf.Scope == kubeletconfig.ContainerTopologyManagerScope {
+		return string(topologyv1alpha2.BestEffortContainerLevel)
+	}
+	if conf.Policy == kubeletconfig.RestrictedTopologyManagerPolicy && conf.Scope == kubeletconfig.PodTopologyManagerScope {
+		return string(topologyv1alpha2.RestrictedPodLevel)
+	}
+	if conf.Policy == kubeletconfig.RestrictedTopologyManagerPolicy && conf.Scope == kubeletconfig.ContainerTopologyManagerScope {
+		return string(topologyv1alpha2.RestrictedContainerLevel)
+	}
+	return ""
+}
+
+func main() {
+	var nrt topologyv1alpha2.NodeResourceTopology
+	err := json.NewDecoder(os.Stdin).Decode(&nrt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot decode object: %v\n", err)
+	}
+	tm := nodeconfig.TopologyManagerFromNodeResourceTopology(logr.Discard(), &nrt)
+	fmt.Println(fmt.Sprintf(`kubectl patch noderesourcetopologies.topology.node.k8s.io %s --type=merge -p '{"topologyPolicies":["%s"]}'`, nrt.Name, toTopologyManagerPolicy(tm)))
+}


### PR DESCRIPTION
should we need to patch objects with the legacy value of the deprecated `topologyPolicies` field, add helpers to do so.
