### PR TITLE
[KNI] add script helper to patch legacy data

### DIFF
--- a/hack-kni/legacy/README.md
+++ b/hack-kni/legacy/README.md
@@ -3,6 +3,8 @@
 use this tool to automatically set the deprecated `topologyPolicies` field with a value consistent with the content of the NRT object attributes.
 This is effectively a wasteful no-operation which can be needed in corner cases scenarios.
 
+NOTE: you can replace `go run ./nrtpatch.go` with `nrtpatch.sh` in the following lines if you don't have the go toolchain available.
+
 assuming a valid KUBECONFIG
 check the computed value:
 ```

--- a/hack-kni/legacy/nrtpatch.go
+++ b/hack-kni/legacy/nrtpatch.go
@@ -39,6 +39,7 @@ func main() {
 	err := json.NewDecoder(os.Stdin).Decode(&nrt)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cannot decode object: %v\n", err)
+		os.Exit(1)
 	}
 	tm := nodeconfig.TopologyManagerFromNodeResourceTopology(logr.Discard(), &nrt)
 	fmt.Println(fmt.Sprintf(`kubectl patch noderesourcetopologies.topology.node.k8s.io %s --type=merge -p '{"topologyPolicies":["%s"]}'`, nrt.Name, toTopologyManagerPolicy(tm)))

--- a/hack-kni/legacy/nrtpatch.sh
+++ b/hack-kni/legacy/nrtpatch.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eu
+
+# check jq is available - requires set -e
+jq --version > /dev/null
+
+NAME=$( jq -r '.metadata.name' /dev/stdin )
+SCOPE=$( jq -r '.attributes[] | select(.name=="topologyManagerScope").value' /dev/stdin )
+POLICY=$( jq -r '.attributes[] | select(.name=="topologyManagerPolicy").value' /dev/stdin )
+
+FIX=""
+if [[ $POLICY == "single-numa-node" && $SCOPE == "pod" ]]; then
+	FIX="SingleNUMANodePodLevel"
+elif [[ $POLICY == "single-numa-node" && $SCOPE == "container" ]]; then
+	FIX="SingleNUMANodeContainerLevel"
+elif [[ $POLICY == "best-effort" && $SCOPE == "pod" ]]; then
+	FIX="BestEffortPodLevel"
+elif [[ $POLICY == "best-effort" && $SCOPE == "container" ]]; then
+	FIX="BestEffortContainerLevel"
+elif [[ $POLICY == "restricted" && $SCOPE == "pod" ]]; then
+	FIX="RestrictedPodLevel"
+elif [[ $POLICY == "restricted" && $SCOPE == "container" ]]; then
+	FIX="RestrictedContainerLevel"
+elif [[ $POLICY == "none" ]]; then
+	# nothing to do
+	exit 0
+else
+	echo "cannot decode JSON input"
+	exit 1
+fi
+
+echo "kubectl patch noderesourcetopologies.topology.node.k8s.io $NAME --type=merge -p '{\"topologyPolicies\":[\"$FIX\"]}'"


### PR DESCRIPTION
like commit 425004b3f0fe0de12b4d53aa0878f53e4c254a41 , but with a shell script

plus, a small fix: if `nrtpatch.go` faiils, it should exit with error.
