### PR TITLE
[release-4.18] nrt: log: return updated generation value for cache

### DIFF
--- a/RESYNC.log.md
+++ b/RESYNC.log.md
@@ -1,5 +1,7 @@
 | Resync Date | Merge With Upstream Tag/Commit                                                                       | Author      |
 |-------------|------------------------------------------------------------------------------------------------------|-------------|
+| 2025.06.16  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ffe2ce2f11273a17cf1a70e657b77ee03ac2f270 | shajmakh    | cherrypick
+| 2025.06.16  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/4bf93e9f74bf41374a4342215ac88116b91c760a | shajmakh    | cherrypick
 | 2024.09.26  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/bb56af11184a0f6ed33e2fc8b189a5b1ccfc60e4 | ffromani    |
 | 2024.06.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/2c1c0cfe6134c5d55a23dae1726264664a943f4b | ffromani    |
 | 2024.05.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/0834feb92676712cebe8290615ce1c47537fe078 | ffromani    |


### PR DESCRIPTION
cherry-picked from u/s. please check the commits details.
