### PR TITLE
[KNI] go.mod: revert version to 1.21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.21
 
       - name: Run integration test
         run:
@@ -64,7 +64,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.22
+          go-version: 1.21
 
       - name: Verify vendoring
         run: ./hack-kni/verify-vendoring.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.22
+          go-version: 1.21
 
       - name: Set release version env var
         run: |

--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.22.2
+ENV GOVERSION=1.21.11
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/scheduler-plugins
 
-go 1.22
+go 1.21.0
+
+toolchain go1.21.11
 
 require (
 	github.com/containers/common v0.60.4

--- a/vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testdata/a/foo.txt
+++ b/vendor/k8s.io/kubernetes/test/e2e/framework/testfiles/testdata/a/foo.txt
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
we should be buildable with golang 1.21, and
we don't use 1.22 features directly nor in deps, so let's revert to 1.21.
