### PR TITLE
[KNI] downgrade the golang builder to 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.22
 
       - name: Run integration test
         run:
@@ -64,7 +64,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.23
+          go-version: 1.22
 
       - name: Verify vendoring
         run: ./hack-kni/verify-vendoring.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v3
         id: go
         with:
-          go-version: 1.23
+          go-version: 1.22
 
       - name: Set release version env var
         run: |

--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.23.2
+ENV GOVERSION=1.22.12
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}


### PR DESCRIPTION
the jump to 1.23 was unwarranted. We will maybe
retry later with more caution and planning
