### PR TITLE
[KNI] CVE-2025-22871: tools: bump golang builder

### DIFF
--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.23.2
+ENV GOVERSION=1.23.9
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}


### PR DESCRIPTION
Bump the minimum required version of golang builder to consume the fix for the aforementioned CVE
