### PR TITLE
[KNI]: inject version for debug

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -201,6 +201,7 @@ spec:
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])
+      - COMMIT_SHA=$(tasks.clone-repository.results.commit)
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: PRIVILEGED_NESTED

--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -2,11 +2,15 @@ ARG RHEL_VERSION=9.4
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 AS builder
 
+ARG COMMIT_SHA
+ARG OCP_MAJOR_VERSION=4
+ARG OCP_MINOR_VERSION=20
+
 WORKDIR /app
 
 COPY . .
 
-RUN GOEXPERIMENT=strictfipsruntime GOOS=linux CGO_ENABLED=1 go build -tags strictfipsruntime -o bin/noderesourcetopology-plugin cmd/noderesourcetopology-plugin/main.go
+RUN GOEXPERIMENT=strictfipsruntime GOOS=linux CGO_ENABLED=1 go build -ldflags "-X k8s.io/component-base/version.gitMajor=${OCP_MAJOR_VERSION} -X k8s.io/component-base/version.gitMinor=${OCP_MINOR_VERSION} -X k8s.io/component-base/version.gitCommit=${COMMIT_SHA}  -w" -tags strictfipsruntime -o bin/noderesourcetopology-plugin cmd/noderesourcetopology-plugin/main.go
 
 FROM registry.redhat.io/rhel9-4-els/rhel-minimal:${RHEL_VERSION}
 

--- a/cmd/noderesourcetopology-plugin/main.go
+++ b/cmd/noderesourcetopology-plugin/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"time"
@@ -71,5 +72,5 @@ func main() {
 
 func printVersion(logh logr.Logger) {
 	ver := version.Get()
-	logh.Info("starting noderesourcetopology scheduler", "version", ver.GitVersion, "goversion", ver.GoVersion, "platform", ver.Platform)
+	logh.Info("starting noderesourcetopology scheduler", "version", fmt.Sprintf("%s.%s", ver.Major, ver.Minor), "gitcommit", ver.GitCommit, "goversion", ver.GoVersion, "platform", ver.Platform)
 }


### PR DESCRIPTION
To aid troubleshooting, we want to continue injecting version information into the binary, as we’ve done previously downstream. In the past, we relied on cpass to provide the full x.y.z version via environment variables. However, since Konflux does not expose the same variables, we will instead embed the x.y version along with the Git commit hash.


There was an ongoing disussion done for this work [here](https://github.com/openshift-kni/scheduler-plugins/pull/333#discussion_r2149983553)
