### PR TITLE
[release-4.18]: Inject version konflux builds

### DIFF
--- a/.tekton/noderesourcetopology-scheduler-4-18-pull-request.yaml
+++ b/.tekton/noderesourcetopology-scheduler-4-18-pull-request.yaml
@@ -234,6 +234,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - COMMIT_SHA=$(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED

--- a/.tekton/noderesourcetopology-scheduler-4-18-push.yaml
+++ b/.tekton/noderesourcetopology-scheduler-4-18-push.yaml
@@ -231,6 +231,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - COMMIT_SHA=$(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED

--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -1,10 +1,14 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.23@sha256:4805e1cb2d1bd9d3c5de5d6986056bbda94ca7b01642f721d83d26579d333c60 as builder
 
+ARG COMMIT_SHA
+ARG OCP_MAJOR_VERSION=4
+ARG OCP_MINOR_VERSION=18
+
 WORKDIR /app
 
 COPY . .
 
-RUN GOEXPERIMENT=strictfipsruntime GOOS=linux CGO_ENABLED=1 go build -tags strictfipsruntime -o bin/noderesourcetopology-plugin cmd/noderesourcetopology-plugin/main.go
+RUN GOEXPERIMENT=strictfipsruntime GOOS=linux CGO_ENABLED=1 go build -ldflags "-X k8s.io/component-base/version.gitMajor=${OCP_MAJOR_VERSION} -X k8s.io/component-base/version.gitMinor=${OCP_MINOR_VERSION} -X k8s.io/component-base/version.gitCommit=${COMMIT_SHA}  -w" -tags strictfipsruntime -o bin/noderesourcetopology-plugin cmd/noderesourcetopology-plugin/main.go
 
 FROM registry.redhat.io/rhel9-4-els/rhel-minimal:9.4@sha256:9577a9ed1707ba2a1a229559d188a015cf3b20b18e4b83541f427697d1c0b8df
 

--- a/cmd/noderesourcetopology-plugin/main.go
+++ b/cmd/noderesourcetopology-plugin/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"math/rand"
 	"os"
 	"time"
@@ -71,5 +72,5 @@ func main() {
 
 func printVersion(logh logr.Logger) {
 	ver := version.Get()
-	logh.Info("starting noderesourcetopology scheduler", "version", ver.GitVersion, "goversion", ver.GoVersion, "platform", ver.Platform)
+	logh.Info("starting noderesourcetopology scheduler", "version", fmt.Sprintf("%s.%s", ver.Major, ver.Minor), "gitcommit", ver.GitCommit, "goversion", ver.GoVersion, "platform", ver.Platform)
 }


### PR DESCRIPTION
To aid troubleshooting, we want to continue injecting version information into the binary, as we’ve done previously downstream. In the past, we relied on cpass to provide the full x.y.z version via environment variables. However, since Konflux does not expose the same variables, we will instead embed the x.y version along with the Git commit hash.

There was an ongoing discussion done for this work https://github.com/openshift-kni/scheduler-plugins/pull/333#discussion_r2149983553