### PR TITLE
[release-4.14]: Inject version konflux builds

### DIFF
--- a/.tekton/noderesourcetopology-scheduler-4-14-pull-request.yaml
+++ b/.tekton/noderesourcetopology-scheduler-4-14-pull-request.yaml
@@ -233,6 +233,7 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS
         value:
+        - COMMIT_SHA=$(tasks.clone-repository.results.commit)
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)

--- a/.tekton/noderesourcetopology-scheduler-4-14-push.yaml
+++ b/.tekton/noderesourcetopology-scheduler-4-14-push.yaml
@@ -231,6 +231,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - COMMIT_SHA=$(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       - name: PRIVILEGED_NESTED

--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -1,10 +1,14 @@
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.20@sha256:f814c21d78b9c98efd8cab17ead9d6fd1480341b5f7664fe5c75606b8d8f2be2 as builder
 
+ARG COMMIT_SHA
+ARG OCP_MAJOR_VERSION=4
+ARG OCP_MINOR_VERSION=14
+
 WORKDIR /app
 
 COPY . .
 
-RUN GOEXPERIMENT=strictfipsruntime GOOS=linux CGO_ENABLED=1 go build -tags strictfipsruntime -o bin/noderesourcetopology-plugin cmd/noderesourcetopology-plugin/main.go
+RUN GOEXPERIMENT=strictfipsruntime GOOS=linux CGO_ENABLED=1 go build -ldflags "-X k8s.io/component-base/version.gitMajor=${OCP_MAJOR_VERSION} -X k8s.io/component-base/version.gitMinor=${OCP_MINOR_VERSION} -X k8s.io/component-base/version.gitCommit=${COMMIT_SHA}  -w" -tags strictfipsruntime -o bin/noderesourcetopology-plugin cmd/noderesourcetopology-plugin/main.go
 
 FROM registry.redhat.io/rhel9-4-els/rhel-minimal:9.4@sha256:9577a9ed1707ba2a1a229559d188a015cf3b20b18e4b83541f427697d1c0b8df
 

--- a/cmd/noderesourcetopology-plugin/main.go
+++ b/cmd/noderesourcetopology-plugin/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"os"
 	"time"
@@ -97,5 +98,5 @@ func main() {
 
 func printVersion(logh logr.Logger) {
 	ver := version.Get()
-	logh.Info("starting noderesourcetopology scheduler", "version", ver.GitVersion, "goversion", ver.GoVersion, "platform", ver.Platform)
+	logh.Info("starting noderesourcetopology scheduler", "version", fmt.Sprintf("%s.%s", ver.Major, ver.Minor), "gitcommit", ver.GitCommit, "goversion", ver.GoVersion, "platform", ver.Platform)
 }


### PR DESCRIPTION
To aid troubleshooting, we want to continue injecting version information into the binary, as we’ve done previously downstream. In the past, we relied on cpass to provide the full x.y.z version via environment variables. However, since Konflux does not expose the same variables, we will instead embed the x.y version along with the Git commit hash.

There was an ongoing discussion done for this work https://github.com/openshift-kni/scheduler-plugins/pull/333#discussion_r2149983553