### PR TITLE
[release-4.17][KNI][upstream] nrt: log: introduce and use "generation" for cache

### DIFF
--- a/RESYNC.log.md
+++ b/RESYNC.log.md
@@ -1,24 +1,27 @@
-| Resync Date | Merge With Upstream Tag/Commit                                                                       | Author      |
-|-------------|------------------------------------------------------------------------------------------------------|-------------|
-| 2024.06.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/2c1c0cfe6134c5d55a23dae1726264664a943f4b | ffromani    |
-| 2024.05.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/0834feb92676712cebe8290615ce1c47537fe078 | ffromani    |
-| 2024.05.07  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/70981813a19f16c4202f6f74a2525bf917b63685 | ffromani    |
-| 2024.01.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/93c518b7350fdba82238daa559cb0c11a9353e87 | ffromani    |
-| 2024.01.19  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/51aeff68f8ce110a5dd7386ec2cee2275c78a0c7 | ffromani    | + cherry-picks on top
-| 2023.06.01  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/cbf2979725a3be327c1a18a74375e06498bd3419 | ffromani    |
-| 2023.05.19  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/0ab88ad4a346d4e8682240c1f3817816a4298f40 | ffromani    |
-| 2023.05.09  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/f8a1d6585f44878521a61411788aa4d5cb0488f0 | ffromani    |
-| 2023.03.28  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ab6c864e24ca08a38efc609524ce10bce8d3db3b | ffromani    |
-| 2023.03.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/f303398b77c767ef1c6fab56ded0858a5dedbdd2 | ffromani    |
-| 2022.12.15A | https://github.com/kubernetes-sigs/scheduler-plugins/commit/07d6327976a4b60662a4b5a677f15dea1f343b57 | fromanirh   |
-| 2022.12.15  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/a4d42b75ae5c51ff8a3037854057d7ffc81ab3f6 | fromanirh   |
-| 2022.10.21  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/66dabd41eb42dd6e96e1762c89cf96b4eff05bdd | fromanirh   |
-| 2022.10.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/81fb4607af1d45ebf76eb7fbd0eb7ddba7abc959 | swatisehgal |
-| 2022.07.06  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/6aadda4e9213fd0f71807cd6630eb8e58db740fd | swatisehgal |
-| 2022.06.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/843d47374bba691f13558806e8fddb866bfb1b9e | swatisehgal |
-| 2022.06.23  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/54bd848cd75ce5c0b6953733b0e477c47aa356a9 | swatisehgal |
-| 2022.05.03  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/7a6dcdc99b1ee9a324823eaf98718cfd9e98e805 | fromanirh   |
-| 2022.03.10  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/2b3439076c54579c3ecdacfc71ca00a23f1e42f8 | fromanirh   |
-| 2022.01.21  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ec632c3d7e04b7b372f9a6f4338b0dbc53ef3d46 | fromanirh   |
-| 2021.12.23  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/7cf6512bd726f0d30b2ab32443af867a0b849da8 | fromanirh   |
-| 2021.12.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/b8d13e17a3e1f633d72d71276a3da6fecf89f2e3 | Tal-or      |
+| Resync Date | Merge With Upstream Tag/Commit                                                                        | Author      |
+|-------------|-------------------------------------------------------------------------------------------------------|-------------|
+| 2025.06.20  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ffe2ce2f11273a17cf1a70e657b77ee03ac2f270  | shajmakh    | cherry-pick
+| 2025.06.20  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/4bf93e9f74bf41374a4342215ac88116b91c760a  | shajmakh    | cherry-pick
+| 2025.06.20  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/0dae3ecb22f5469912dd28e8509fc722341cfa05  | shajmakh    | cherry-pick
+| 2024.06.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/2c1c0cfe6134c5d55a23dae1726264664a943f4b  | ffromani    |
+| 2024.05.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/0834feb92676712cebe8290615ce1c47537fe078  | ffromani    |
+| 2024.05.07  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/70981813a19f16c4202f6f74a2525bf917b63685  | ffromani    |
+| 2024.01.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/93c518b7350fdba82238daa559cb0c11a9353e87  | ffromani    |
+| 2024.01.19  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/51aeff68f8ce110a5dd7386ec2cee2275c78a0c7  | ffromani    | + cherry-picks on top
+| 2023.06.01  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/cbf2979725a3be327c1a18a74375e06498bd3419  | ffromani    |
+| 2023.05.19  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/0ab88ad4a346d4e8682240c1f3817816a4298f40  | ffromani    |
+| 2023.05.09  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/f8a1d6585f44878521a61411788aa4d5cb0488f0  | ffromani    |
+| 2023.03.28  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ab6c864e24ca08a38efc609524ce10bce8d3db3b  | ffromani    |
+| 2023.03.24  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/f303398b77c767ef1c6fab56ded0858a5dedbdd2  | ffromani    |
+| 2022.12.15A | https://github.com/kubernetes-sigs/scheduler-plugins/commit/07d6327976a4b60662a4b5a677f15dea1f343b57  | fromanirh   |
+| 2022.12.15  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/a4d42b75ae5c51ff8a3037854057d7ffc81ab3f6  | fromanirh   |
+| 2022.10.21  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/66dabd41eb42dd6e96e1762c89cf96b4eff05bdd  | fromanirh   |
+| 2022.10.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/81fb4607af1d45ebf76eb7fbd0eb7ddba7abc959  | swatisehgal |
+| 2022.07.06  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/6aadda4e9213fd0f71807cd6630eb8e58db740fd  | swatisehgal |
+| 2022.06.29  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/843d47374bba691f13558806e8fddb866bfb1b9e  | swatisehgal |
+| 2022.06.23  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/54bd848cd75ce5c0b6953733b0e477c47aa356a9  | swatisehgal |
+| 2022.05.03  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/7a6dcdc99b1ee9a324823eaf98718cfd9e98e805  | fromanirh   |
+| 2022.03.10  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/2b3439076c54579c3ecdacfc71ca00a23f1e42f8  | fromanirh   |
+| 2022.01.21  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/ec632c3d7e04b7b372f9a6f4338b0dbc53ef3d46  | fromanirh   |
+| 2021.12.23  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/7cf6512bd726f0d30b2ab32443af867a0b849da8  | fromanirh   |
+| 2021.12.11  | https://github.com/kubernetes-sigs/scheduler-plugins/commit/b8d13e17a3e1f633d72d71276a3da6fecf89f2e3  | Tal-or      |

--- a/pkg/noderesourcetopology/cache/cache_test.go
+++ b/pkg/noderesourcetopology/cache/cache_test.go
@@ -100,10 +100,10 @@ func checkGetCachedNRTCopy(t *testing.T, makeCache func(client ctrlclient.WithWa
 				nrtCache.NodeHasForeignPods(tc.nodeName, pod)
 			}
 
-			gotNRT, gotOK := nrtCache.GetCachedNRTCopy(ctx, tc.nodeName, pod)
+			gotNRT, gotInfo := nrtCache.GetCachedNRTCopy(ctx, tc.nodeName, pod)
 
-			if gotOK != tc.expectedOK {
-				t.Fatalf("unexpected object status from cache: got: %v expected: %v", gotOK, tc.expectedOK)
+			if gotInfo.Fresh != tc.expectedOK {
+				t.Fatalf("unexpected object status from cache: got: %v expected: %v", gotInfo.Fresh, tc.expectedOK)
 			}
 			if gotNRT != nil && tc.expectedNRT == nil {
 				t.Fatalf("object from cache not nil but expected nil")

--- a/pkg/noderesourcetopology/cache/discardreserved.go
+++ b/pkg/noderesourcetopology/cache/discardreserved.go
@@ -58,20 +58,21 @@ func NewDiscardReserved(lh logr.Logger, client ctrlclient.Client) Interface {
 	}
 }
 
-func (pt *DiscardReserved) GetCachedNRTCopy(ctx context.Context, nodeName string, _ *corev1.Pod) (*topologyv1alpha2.NodeResourceTopology, bool) {
+func (pt *DiscardReserved) GetCachedNRTCopy(ctx context.Context, nodeName string, _ *corev1.Pod) (*topologyv1alpha2.NodeResourceTopology, CachedNRTInfo) {
 	pt.rMutex.RLock()
 	defer pt.rMutex.RUnlock()
 	if t, ok := pt.reservationMap[nodeName]; ok {
 		if len(t) > 0 {
-			return nil, false
+			return nil, CachedNRTInfo{}
 		}
 	}
 
+	info := CachedNRTInfo{Fresh: true}
 	nrt := &topologyv1alpha2.NodeResourceTopology{}
 	if err := pt.client.Get(ctx, types.NamespacedName{Name: nodeName}, nrt); err != nil {
-		return nil, true
+		return nil, info
 	}
-	return nrt, true
+	return nrt, info
 }
 
 func (pt *DiscardReserved) NodeMaybeOverReserved(nodeName string, pod *corev1.Pod) {}

--- a/pkg/noderesourcetopology/cache/discardreserved_test.go
+++ b/pkg/noderesourcetopology/cache/discardreserved_test.go
@@ -66,8 +66,8 @@ func TestDiscardReservedNodesGetNRTCopyFails(t *testing.T) {
 		},
 	}
 
-	nrtObj, ok := nrtCache.GetCachedNRTCopy(context.Background(), "node1", &corev1.Pod{})
-	if ok {
+	nrtObj, nrtInfo := nrtCache.GetCachedNRTCopy(context.Background(), "node1", &corev1.Pod{})
+	if nrtInfo.Fresh {
 		t.Fatal("expected false\ngot true\n")
 	}
 	if nrtObj != nil {

--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -340,7 +340,7 @@ func (ov *OverReserve) Resync() {
 }
 
 // FlushNodes drops all the cached information about a given node, resetting its state clean.
-func (ov *OverReserve) FlushNodes(lh logr.Logger, nrts ...*topologyv1alpha2.NodeResourceTopology) {
+func (ov *OverReserve) FlushNodes(lh logr.Logger, nrts ...*topologyv1alpha2.NodeResourceTopology) uint64 {
 	ov.lock.Lock()
 	defer ov.lock.Unlock()
 
@@ -354,12 +354,14 @@ func (ov *OverReserve) FlushNodes(lh logr.Logger, nrts ...*topologyv1alpha2.Node
 	}
 
 	if len(nrts) == 0 {
-		return
+		return ov.generation
 	}
 
 	// increase only if we mutated the internal state
 	ov.generation += 1
 	lh.V(2).Info("generation", "new", ov.generation)
+	return ov.generation
+
 }
 
 // to be used only in tests

--- a/pkg/noderesourcetopology/cache/overreserve.go
+++ b/pkg/noderesourcetopology/cache/overreserve.go
@@ -101,17 +101,16 @@ func NewOverReserve(ctx context.Context, lh logr.Logger, cfg *apiconfig.NodeReso
 func (ov *OverReserve) GetCachedNRTCopy(ctx context.Context, nodeName string, pod *corev1.Pod) (*topologyv1alpha2.NodeResourceTopology, CachedNRTInfo) {
 	ov.lock.Lock()
 	defer ov.lock.Unlock()
+	info := CachedNRTInfo{Generation: ov.generation}
 	if ov.nodesWithForeignPods.IsSet(nodeName) {
-		return nil, CachedNRTInfo{}
+		return nil, info
 	}
 
-	info := CachedNRTInfo{Fresh: true}
+	info.Fresh = true
 	nrt := ov.nrts.GetNRTCopyByNodeName(nodeName)
 	if nrt == nil {
 		return nil, info
 	}
-
-	info.Generation = ov.generation
 	nodeAssumedResources, ok := ov.assumedResources[nodeName]
 	if !ok {
 		return nrt, info

--- a/pkg/noderesourcetopology/cache/overreserve_test.go
+++ b/pkg/noderesourcetopology/cache/overreserve_test.go
@@ -720,8 +720,8 @@ func TestNodeWithForeignPods(t *testing.T) {
 		t.Errorf("unexpected dirty nodes: %v", nodes.MaybeOverReserved)
 	}
 
-	_, ok := nrtCache.GetCachedNRTCopy(context.Background(), target, &corev1.Pod{})
-	if ok {
+	_, info := nrtCache.GetCachedNRTCopy(context.Background(), target, &corev1.Pod{})
+	if info.Fresh {
 		t.Errorf("succesfully got node with foreign pods!")
 	}
 }

--- a/pkg/noderesourcetopology/cache/passthrough.go
+++ b/pkg/noderesourcetopology/cache/passthrough.go
@@ -40,14 +40,15 @@ func NewPassthrough(lh logr.Logger, client ctrlclient.Client) Interface {
 	}
 }
 
-func (pt Passthrough) GetCachedNRTCopy(ctx context.Context, nodeName string, _ *corev1.Pod) (*topologyv1alpha2.NodeResourceTopology, bool) {
+func (pt Passthrough) GetCachedNRTCopy(ctx context.Context, nodeName string, _ *corev1.Pod) (*topologyv1alpha2.NodeResourceTopology, CachedNRTInfo) {
 	pt.lh.V(5).Info("lister for NRT plugin")
+	info := CachedNRTInfo{Fresh: true}
 	nrt := &topologyv1alpha2.NodeResourceTopology{}
 	if err := pt.client.Get(ctx, types.NamespacedName{Name: nodeName}, nrt); err != nil {
 		pt.lh.V(5).Error(err, "cannot get nrts from lister")
-		return nil, true
+		return nil, info
 	}
-	return nrt, true
+	return nrt, info
 }
 
 func (pt Passthrough) NodeMaybeOverReserved(nodeName string, pod *corev1.Pod)  {}

--- a/pkg/noderesourcetopology/filter.go
+++ b/pkg/noderesourcetopology/filter.go
@@ -196,8 +196,9 @@ func (tm *TopologyMatch) Filter(ctx context.Context, cycleState *framework.Cycle
 	lh.V(4).Info(logging.FlowBegin)
 	defer lh.V(4).Info(logging.FlowEnd)
 
-	nodeTopology, ok := tm.nrtCache.GetCachedNRTCopy(ctx, nodeName, pod)
-	if !ok {
+	nodeTopology, info := tm.nrtCache.GetCachedNRTCopy(ctx, nodeName, pod)
+	lh = lh.WithValues(logging.KeyGeneration, info.Generation)
+	if !info.Fresh {
 		lh.V(2).Info("invalid topology data")
 		return framework.NewStatus(framework.Unschedulable, "invalid node topology data")
 	}

--- a/pkg/noderesourcetopology/logging/logging.go
+++ b/pkg/noderesourcetopology/logging/logging.go
@@ -17,9 +17,7 @@ limitations under the License.
 package logging
 
 import (
-	"fmt"
 	"reflect"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -33,6 +31,7 @@ const (
 	KeyFlow          string = "flow"
 	KeyContainer     string = "container"
 	KeyContainerKind string = "kind"
+	KeyGeneration    string = "generation"
 )
 
 const (
@@ -62,8 +61,4 @@ func PodUID(pod *corev1.Pod) string {
 		return "<nil>"
 	}
 	return string(pod.GetUID())
-}
-
-func TimeLogID() string {
-	return fmt.Sprintf("uts/%v", time.Now().UnixMilli())
 }

--- a/pkg/noderesourcetopology/score.go
+++ b/pkg/noderesourcetopology/score.go
@@ -73,9 +73,9 @@ func (tm *TopologyMatch) Score(ctx context.Context, state *framework.CycleState,
 		return framework.MaxNodeScore, nil
 	}
 
-	nodeTopology, ok := tm.nrtCache.GetCachedNRTCopy(ctx, nodeName, pod)
-
-	if !ok {
+	nodeTopology, info := tm.nrtCache.GetCachedNRTCopy(ctx, nodeName, pod)
+	lh = lh.WithValues(logging.KeyGeneration, info.Generation)
+	if !info.Fresh {
 		lh.V(4).Info("noderesourcetopology is not valid for node")
 		return 0, nil
 	}


### PR DESCRIPTION
Cherry-pick commits from u/s to support logging NRT cache generation. Please see commits for details. 