### PR TITLE
konflux: fixed apply-tags tasks params

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -517,8 +517,10 @@ spec:
       - "false"
   - name: apply-tags
     params:
-    - name: IMAGE
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     runAfter:
     - build-image-index
     taskRef:


### PR DESCRIPTION
This will fix the konflux pipeline, which has been failing recently.

