### PR TITLE
konflux: update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,27 @@
     "gomod": {
         "enabled": false
     },
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["minor"],
+            "enabled": false
+        },
+        {
+            "addLabels": ["approved", "lgtm"],
+            "autoApprove": true,
+            "automerge": true,
+            "enabled": true,
+            "ignoreTests": false,
+            "matchDatasources": ["docker"],
+            "matchManagers": ["dockerfile"],
+            "matchPaths": ["build/noderesourcetopology-plugin/konflux.Dockerfile"],
+            "matchUpdateTypes": ["digest"],
+            "platformAutomerge": true
+        }
+    ],    
     "prConcurrentLimit": 0,
     "pruneBranchAfterAutomerge": true,
     "tekton": {
-        "autoApprove": true,
-        "automerge": true,
         "enabled": true,
         "fileMatch": [
             "\\.yaml$",
@@ -19,6 +35,21 @@
         "includePaths": [
             ".tekton/**"
         ],
-        "platformAutomerge": true
+        "platformAutomerge": true,
+        "schedule": [
+            "at any time"
+        ],
+        "packageRules": [
+            {
+                "addLabels": [
+                    "approved",
+                    "lgtm"
+                ],
+                "automerge": true,
+                "matchUpdateTypes": [
+                    "digest"
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
- Set packageRules to ignore all chore(deps) updates for minor versions. We currenly want control over the minor versions of base images and go versions and we also do not want to use the latest minor version of a package in all branches
- Set auto lgtm and approve for tekton file digest updates
- Add Renovate package rule to auto label (lgtm and approve), auto-approve and auto-merge Docker digest updates under build/noderesourcetopology-plugin/konflux.Dockerfile with platform automerge enabled
