### PR TITLE
[release-4.18][KNI] snyk: exclude fsnotify

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -14,6 +14,7 @@ exclude:
     - vendor/sigs.k8s.io/controller-runtime/pkg/internal/testing/process/process.go
     - vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go
     - vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go
+    - vendor/github.com/fsnotify/fsnotify/**
     - vendor/github.com/google/uuid/hash.go
     - vendor/github.com/paypal/load-watcher/pkg/watcher/internal/metricsprovider/prometheus.go
     - vendor/github.com/spf13/cobra/command.go


### PR DESCRIPTION
There is no clear reason why snyk scan started failing on this out of the blue. Add the package path to the exclude list to exclude its files from the scan.

