### PR TITLE
[release-4.13][KNI] hack-kni: skip commit verification for konflux commits

### DIFF
--- a/hack-kni/verify-commits.sh
+++ b/hack-kni/verify-commits.sh
@@ -54,6 +54,13 @@ echo "---"
 # list commits
 for commitish in $( git log --oneline --no-merges "$latest_upstream_commit"..HEAD | cut -d' ' -f 1); do
   echo "CHECK: $commitish"
+
+  author_name=$( git log --pretty=format:"%an" -n 1 "$commitish" )
+  if [[ "$author_name" == red-hat-konflux* ]]; then
+    echo "Skip verifying commit from Konflux bot"
+    continue
+  fi
+
   .github/hooks/commit-msg $( git log --format=%s -n 1 "$commitish" )
   if [[ "$?" != "0" ]]; then
     echo "-> FAIL: $commitish"


### PR DESCRIPTION
Skip validating konflux commits structure. Usually konflux bot commits signed off by either "red-hat-konflux" or "red-hat-konflux[bot]".


(cherry picked from commit dccb425b5f1ccf0ffefaade0b1bf7447d9735f78)

