### PR TITLE
[KNI] AA: go builders: bump to 1.24

### DIFF
--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 WORKDIR /go/src/sigs.k8s.io/scheduler-plugins
 COPY . .

--- a/build/noderesourcetopology-plugin/Dockerfile.tools
+++ b/build/noderesourcetopology-plugin/Dockerfile.tools
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT=/usr/local/go
-ENV GOVERSION=1.23.2
+ENV GOVERSION=1.24.7
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}

--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -1,4 +1,5 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 as builder
+# follow https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=70135
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24@sha256:b91431604c435f3cabec20ddb653c0537c8ba8097ada57960d54a1266f95a7c3 as builder
 
 ARG COMMIT_SHA
 ARG OCP_MAJOR_VERSION=4


### PR DESCRIPTION
 Follow Openshift and bump to go v1.24.
    
Note: the below AI-Attribution tag was genereted using the
https://aiattribution.github.io/create-attribution to interpret it
please paste its value in
https://aiattribution.github.io/interpret-attribution.
    
Assisted-by: Cursor v1.2.2
AI-Attribution: AIA PAI Ce Hin R Cursor v1.2.2 model:gpt-5 v1.0