### PR TITLE
[KNI] tekton: redirect `master` to 4.21

### DIFF
--- a/.tekton/noderesourcetopology-scheduler-4-21-pull-request.yaml
+++ b/.tekton/noderesourcetopology-scheduler-4-21-pull-request.yaml
@@ -12,10 +12,10 @@ metadata:
       == "master"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: noderesourcetopology-scheduler-4-20
-    appstudio.openshift.io/component: noderesourcetopology-scheduler-4-20
+    appstudio.openshift.io/application: noderesourcetopology-scheduler-4-21
+    appstudio.openshift.io/component: noderesourcetopology-scheduler-4-21
     pipelines.appstudio.openshift.io/type: build
-  name: noderesourcetopology-scheduler-4-20-on-pull-request
+  name: noderesourcetopology-scheduler-4-21-on-pull-request
   namespace: telco-5g-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/telco-5g-tenant/noderesourcetopology-scheduler-4-20:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/noderesourcetopology-scheduler-4-21:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -39,7 +39,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-noderesourcetopology-scheduler-4-20
+    serviceAccountName: build-pipeline-noderesourcetopology-scheduler-4-21
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/noderesourcetopology-scheduler-4-21-push.yaml
+++ b/.tekton/noderesourcetopology-scheduler-4-21-push.yaml
@@ -11,10 +11,10 @@ metadata:
       == "master"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: noderesourcetopology-scheduler-4-20
-    appstudio.openshift.io/component: noderesourcetopology-scheduler-4-20
+    appstudio.openshift.io/application: noderesourcetopology-scheduler-4-21
+    appstudio.openshift.io/component: noderesourcetopology-scheduler-4-21
     pipelines.appstudio.openshift.io/type: build
-  name: noderesourcetopology-scheduler-4-20-on-push
+  name: noderesourcetopology-scheduler-4-21-on-push
   namespace: telco-5g-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/telco-5g-tenant/noderesourcetopology-scheduler-4-20:{{revision}}
+    value: quay.io/redhat-user-workloads/telco-5g-tenant/noderesourcetopology-scheduler-4-21:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -36,7 +36,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-noderesourcetopology-scheduler-4-20
+    serviceAccountName: build-pipeline-noderesourcetopology-scheduler-4-21
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
release-4.20 is branched out, redirect `master`'s tekton files to 4.21.

