### PR TITLE
WIP: [KNI] pfpstatus: optional HTTP endpoint

### DIFF
--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -21,6 +21,7 @@ ARG RELEASE_VERSION
 RUN RELEASE_VERSION=${RELEASE_VERSION} make -f Makefile.kni build-noderesourcetopology-plugin
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal
+RUN microdnf install -y net-tools procps-ng && microdnf clean -y all
 COPY --from=builder /go/src/sigs.k8s.io/scheduler-plugins/bin/noderesourcetopology-plugin /bin/kube-scheduler
 USER 65532:65532
 WORKDIR /bin

--- a/cmd/noderesourcetopology-plugin/main.go
+++ b/cmd/noderesourcetopology-plugin/main.go
@@ -48,7 +48,9 @@ func main() {
 
 	rand.Seed(time.Now().UnixNano())
 
-	knistatus.Setup(logh)
+	params := knistatus.DefaultParams()
+	knistatus.ParamsFromEnv(logh, &params)
+	knistatus.Setup(logh, params)
 
 	// Register custom plugins to the scheduler framework.
 	// Later they can consist of scheduler profile(s) and hence

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.7.0
 	github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2
-	github.com/k8stopologyawareschedwg/podfingerprint v0.2.2
+	github.com/k8stopologyawareschedwg/podfingerprint v0.2.3-0.20250917082921-b1753a88551b
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/paypal/load-watcher v0.2.4
 	github.com/spf13/pflag v1.0.6
@@ -184,3 +184,5 @@ replace k8s.io/externaljwt => k8s.io/externaljwt v0.33.3
 replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.3
 
 replace k8s.io/sample-controller => k8s.io/sample-controller v0.33.3
+
+replace github.com/k8stopologyawareschedwg/podfingerprint => github.com/k8stopologyawareschedwg/podfingerprint v0.2.3-0.20250917082921-b1753a88551b

--- a/go.sum
+++ b/go.sum
@@ -2136,8 +2136,8 @@ github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2 h1:uAwqOtyrFYggq3pVf3hs1XKkBxrQ8dkgjWz3LCLJsiY=
 github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.1.2/go.mod h1:LBzS4n6GX1C69tzSd5EibZ9cGOXFuHP7GxEMDYVe1sM=
-github.com/k8stopologyawareschedwg/podfingerprint v0.2.2 h1:iFHPfZInM9pz2neye5RdmORMp1hPmte1EGJYpOOzZVg=
-github.com/k8stopologyawareschedwg/podfingerprint v0.2.2/go.mod h1:C23pM15t06dXg/OihGlqBvnYzLr+MXDXJ7zMfbNAyXI=
+github.com/k8stopologyawareschedwg/podfingerprint v0.2.3-0.20250917082921-b1753a88551b h1:AACQ5w6RJxrXsAuk7RbbYNs/TbdCniDvp6OCjpDDtE0=
+github.com/k8stopologyawareschedwg/podfingerprint v0.2.3-0.20250917082921-b1753a88551b/go.mod h1:CUzcssOjhPN5v+2XmQIHB27EgZ6OQBBDu3/Lfyq9i2k=
 github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=

--- a/pkg-kni/pfpstatus/pfpstatus.go
+++ b/pkg-kni/pfpstatus/pfpstatus.go
@@ -19,105 +19,242 @@ package pfpstatus
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
 	"os"
-	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 
+	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/k8stopologyawareschedwg/podfingerprint"
+	"github.com/k8stopologyawareschedwg/podfingerprint/record"
 )
 
 const (
 	PFPStatusDumpEnvVar string = "PFP_STATUS_DUMP"
+	PFPStatusPortEnvVar string = "PFP_STATUS_PORT"
 )
 
-type StatusInfo struct {
-	podfingerprint.Status
-	LastWrite time.Time `json:"lastWrite"`
-	SeqNo     int64     `json:"seqNo"`
+const (
+	defaultMaxNodes          = 5000
+	defaultMaxSamplesPerNode = 10
+	defaultDumpPeriod        = 10 * time.Second
+)
+
+type HTTPParams struct {
+	Enabled     bool
+	Port        int
+	RequireAuth bool
 }
 
-func Setup(logh logr.Logger) {
+type StorageParams struct {
+	Enabled   bool
+	Directory string
+	Period    time.Duration
+}
+
+type Params struct {
+	HTTP    HTTPParams
+	Storage StorageParams
+}
+
+type environ struct {
+	mu  sync.Mutex
+	rec *record.Recorder
+	lh  logr.Logger
+	cs  kubernetes.Interface
+}
+
+func DefaultParams() Params {
+	return Params{
+		HTTP: HTTPParams{
+			Enabled:     true,
+			Port:        33445,
+			RequireAuth: true,
+		},
+		Storage: StorageParams{
+			Enabled:   false,
+			Directory: "/run/pfpstatus",
+			Period:    10 * time.Second,
+		},
+	}
+}
+
+func ParamsFromEnv(lh logr.Logger, params *Params) {
 	dumpDir, ok := os.LookupEnv(PFPStatusDumpEnvVar)
 	if !ok || dumpDir == "" {
-		logh.Info("PFP Status dump disabled", "variableFound", ok, "valueGiven", dumpDir != "")
-		return
+		params.Storage.Enabled = false
+	} else {
+		params.Storage.Enabled = true
+		params.Storage.Directory = dumpDir
 	}
 
-	logh.Info("PFP Status dump enabled", "statusDirectory", dumpDir)
-
-	ch := make(chan podfingerprint.Status)
-
-	podfingerprint.SetCompletionSink(ch)
-	go RunForever(context.Background(), logh, dumpDir, ch)
-}
-
-func RunForever(ctx context.Context, logger logr.Logger, baseDirectory string, updates <-chan podfingerprint.Status) {
 	// let's try to keep the amount of code we do in init() at minimum.
 	// This may happen if the container didn't have the directory mounted
-	discard := !existsBaseDirectory(baseDirectory)
-	if discard {
-		logger.Info("base directory not found, will discard everything", "baseDirectory", baseDirectory)
+	if !existsBaseDirectory(dumpDir) {
+		lh.Info("base directory not found, will discard everything", "baseDirectory", dumpDir)
+		params.Storage.Enabled = false
 	}
 
-	var seqNo int64 // 63 bits ought to be enough for anybody
-	logger.V(4).Info("status update loop started")
-	defer logger.V(4).Info("status update loop finished")
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		// always keep dequeueing messages to not block the sender
-		case st := <-updates:
-			if discard {
-				return
-			}
-			seqNo += 1
-			// intentionally ignore errors, must keep going
-			sti := StatusInfo{
-				Status:    st,
-				LastWrite: time.Now(),
-				SeqNo:     seqNo,
-			}
-			DumpNodeStatus(baseDirectory, sti)
+	dumpPort, ok := os.LookupEnv(PFPStatusPortEnvVar)
+	if !ok || dumpPort == "" {
+		params.HTTP.Enabled = false
+	} else {
+		port, err := strconv.Atoi(dumpPort)
+		if err != nil {
+			lh.Error(err, "parsing dump port %q", dumpPort)
+			params.HTTP.Enabled = false
+		} else {
+			params.HTTP.Enabled = true
+			params.HTTP.Port = port
 		}
 	}
 }
 
-func nodeNameToFileName(name string) string {
-	return strings.ReplaceAll(name, ".", "_")
+func Setup(logh logr.Logger, params Params) {
+	if !params.Storage.Enabled && !params.HTTP.Enabled {
+		logh.Info("no backend enabled, nothing to do")
+		return
+	}
+
+	logh.Info("Setup in progress", "params", fmt.Sprintf("%+#v", params))
+
+	rec, err := record.NewRecorder(defaultMaxNodes, defaultMaxSamplesPerNode, time.Now)
+	if err != nil {
+		logh.Error(err, "cannot create a status recorder")
+		return
+	}
+
+	ctx := context.Background()
+	env := environ{
+		rec: rec,
+		lh:  logh,
+	}
+
+	ch := make(chan podfingerprint.Status)
+	podfingerprint.SetCompletionSink(ch)
+	go collectLoop(ctx, &env, ch)
+	if params.Storage.Enabled {
+		go dumpLoop(ctx, &env, params.Storage)
+	}
+	if params.HTTP.Enabled {
+		go serveLoop(ctx, &env, params.HTTP)
+	}
 }
 
-func DumpNodeStatus(statusDir string, st StatusInfo) error {
-	nodeName := nodeNameToFileName(st.NodeName)
-
-	dst, err := os.CreateTemp(statusDir, nodeName)
-	if err != nil {
-		return err
+func collectLoop(ctx context.Context, env *environ, updates <-chan podfingerprint.Status) {
+	env.lh.V(4).Info("collect loop started")
+	defer env.lh.V(4).Info("collect loop finished")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case st := <-updates:
+			env.mu.Lock()
+			_ = env.rec.Push(st) // intentionally ignore error
+			env.mu.Unlock()
+		}
 	}
-	if err := json.NewEncoder(dst).Encode(st); err != nil {
-		dst.Close() // swallow error because we want to bubble up the encoding error
-		return err
-	}
-	if err := dst.Close(); err != nil {
-		return err
-	}
-	return os.Rename(dst.Name(), filepath.Join(statusDir, nodeName+".json"))
 }
 
-func LoadNodeStatus(statusDir, nodeName string) (StatusInfo, error) {
-	nodeName = nodeNameToFileName(nodeName)
+func dumpLoop(ctx context.Context, env *environ, params StorageParams) {
+	env.lh.V(4).Info("dump loop started")
+	defer env.lh.V(4).Info("dump loop finished")
+	ticker := time.NewTicker(params.Period)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			env.mu.Lock()
+			snapshot := env.rec.Content()
+			env.mu.Unlock()
 
-	src, err := os.Open(filepath.Join(statusDir, nodeName+".json"))
-	defer src.Close()
-	if err != nil {
-		return StatusInfo{}, err
+			for nodeName, statuses := range snapshot {
+				record.DumpToFile(params.Directory, nodeName, statuses)
+			}
+		}
 	}
-	var st StatusInfo
-	err = json.NewDecoder(src).Decode(&st)
-	return st, err
+}
+
+func serveLoop(ctx context.Context, env *environ, params HTTPParams) {
+	var err error
+	var cs kubernetes.Interface
+	if params.RequireAuth {
+		cs, err = createClient()
+		if err != nil {
+			env.lh.Error(err, "cannot create the authentication client")
+			return
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /pfpstatus", func(w http.ResponseWriter, r *http.Request) {
+		pfpstatusMainHandler(env, w, r)
+	})
+	mux.HandleFunc("GET /pfpstatus/{nodeName}", func(w http.ResponseWriter, r *http.Request) {
+		pfpstatusNodeHandler(env, w, r)
+	})
+	env.lh.Info("Starting PFP server", "port", params.Port, "auth", params.RequireAuth)
+	var handle http.Handler = mux
+	if params.RequireAuth {
+		handle = authMiddleware(mux, cs, env.lh)
+	}
+	err = http.ListenAndServe(fmt.Sprintf(":%d", params.Port), handle)
+	if err != nil {
+		env.lh.Error(err, "cannot serve PFP status")
+	}
+}
+
+func pfpstatusMainHandler(env *environ, w http.ResponseWriter, r *http.Request) {
+	type Response struct {
+		Nodes int `json:"nodes"`
+	}
+	env.mu.Lock()
+	resp := Response{
+		Nodes: env.rec.CountNodes(),
+	}
+	env.mu.Unlock()
+
+	sendContent(env.lh, w, &resp, "generic")
+}
+
+func pfpstatusNodeHandler(env *environ, w http.ResponseWriter, r *http.Request) {
+	nodeName := r.PathValue("nodeName")
+	if nodeName == "" {
+		env.lh.Info("requested pfpstatus for empty node")
+		http.Error(w, "missing node name", http.StatusUnprocessableEntity)
+		return
+	}
+	env.mu.Lock()
+	content, ok := env.rec.ContentForNode(nodeName)
+	env.mu.Unlock()
+
+	if !ok {
+		http.Error(w, "unknown node name", http.StatusUnprocessableEntity)
+		return
+	}
+	sendContent(env.lh, w, content, nodeName)
+}
+
+func sendContent(lh logr.Logger, w http.ResponseWriter, content any, endpoint string) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.WriteHeader(http.StatusOK)
+	err := json.NewEncoder(w).Encode(content)
+	if err != nil {
+		lh.Error(err, "sending back content for endpoint %q", endpoint)
+	}
 }
 
 func existsBaseDirectory(baseDir string) bool {
@@ -126,4 +263,76 @@ func existsBaseDirectory(baseDir string) bool {
 		return false
 	}
 	return info.IsDir()
+}
+
+func isRequestFromLoopback(r *http.Request) bool {
+	// Get the remote host IP, splitting off the port
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// TODO: log
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func authMiddleware(next http.Handler, cs kubernetes.Interface, lh logr.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isRequestFromLoopback(r) {
+			lh.V(2).Info("auth bypass for loopback request", "remoteAddr", r.RemoteAddr)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+			http.Error(w, "Forbidden: Missing Authorization Header", http.StatusForbidden)
+			return
+		}
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+
+		sar := &authv1.SubjectAccessReview{
+			Spec: authv1.SubjectAccessReviewSpec{
+				ResourceAttributes: &authv1.ResourceAttributes{
+					Group:    "sched.openshift-kni.io", // Must match the apiGroup in the ClusterRole
+					Resource: "pfpstatus",              // Must match the resource in the ClusterRole
+					Verb:     "get",                    // Must match the verb in the ClusterRole
+				},
+				Extra: map[string]authv1.ExtraValue{"token": {token}},
+			},
+		}
+
+		sar, err := cs.AuthorizationV1().SubjectAccessReviews().Create(context.Background(), sar, metav1.CreateOptions{})
+		if err != nil {
+			lh.V(4).Error(err, "checking SubjectAccessReview")
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		if !sar.Status.Allowed {
+			lh.V(4).Info("request denied for token", "reason", sar.Status.Reason)
+			http.Error(w, fmt.Sprintf("Forbidden: %s", sar.Status.Reason), http.StatusForbidden)
+			return
+		}
+
+		lh.V(4).Info("request allowed", "reason", sar.Status.Reason)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func createClient() (kubernetes.Interface, error) {
+	var err error
+	var kubeconfig *rest.Config
+
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	if kubeconfigPath != "" {
+		kubeconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	} else {
+		kubeconfig, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to load kubeconfig (path=%s)", kubeconfigPath)
+	}
+
+	return kubernetes.NewForConfig(kubeconfig)
 }

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/.gitignore
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/record/codec.go
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/record/codec.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package record
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func NodeNameToFileName(name string) string {
+	return strings.ReplaceAll(name, ".", "_")
+}
+
+func FileNameToNodeName(name string) string {
+	return strings.ReplaceAll(name, "_", ".")
+}
+
+// DumpToFile encodes in JSON and dumps the given `obj` to a file.
+// `dir` is the base directory on which the file must be created
+// `file` is the name of the file to create in `dir`.
+// The old file, if present, is always updated atomically.
+func DumpToFile(dir, file string, obj any) error {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	dst, err := os.CreateTemp(dir, "__"+file)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(dst.Name()) // either way, we need to get rid of this
+
+	_, err = dst.Write(data)
+	if err != nil {
+		return err
+	}
+
+	err = dst.Close()
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(dst.Name(), filepath.Join(dir, file))
+}
+
+// LoadFromFile decodes the JSON data found in `file` placed in `dir`
+// and stores it into `obj`, which must be a pointer.
+func LoadFromFile(dir, file string, obj any) error {
+	data, err := os.ReadFile(filepath.Join(dir, file))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, obj)
+}

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/record/recorder.go
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/record/recorder.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package record
+
+import (
+	"errors"
+	"time"
+
+	"github.com/k8stopologyawareschedwg/podfingerprint"
+)
+
+var (
+	ErrInvalidCapacity  = errors.New("invalid capacity")
+	ErrInvalidNodeCount = errors.New("invalid node count")
+	ErrMissingNode      = errors.New("missing node")
+	ErrMismatchingNode  = errors.New("mismatching node")
+	ErrTooManyNodes     = errors.New("excessive node count")
+)
+
+// RecordedStatus is a Status plus additional metadata
+type RecordedStatus struct {
+	podfingerprint.Status
+	// RecordTime is a timestamp of when the RecordedStatus was added to the record
+	RecordTime time.Time `json:"recordTime"`
+}
+
+func (rs RecordedStatus) Equal(x RecordedStatus) bool {
+	return rs.Status.Equal(x.Status)
+}
+
+// Timestampr is the function called to get the timestamps. A good default is time.Now
+type Timestamper func() time.Time
+
+// NodeRecorder stores all the recorded statuses for a given node name.
+// Statuses belonging to different nodes won't be accepted.
+type NodeRecorder struct {
+	timestamper func() time.Time
+	nodeName    string // shortcut
+	capacity    int
+	statuses    []RecordedStatus
+}
+
+// NewNodeRecorder creates a new recorder for the given node with the given capacity.
+// The record is a ring buffer, so only the latest <capacity> Statuses are kept at any time.
+// The timestamper callback is used to mark times. Use `time.Now` if unsure.
+// Returns the newly created instance; if parameters are incorrect, returns an error, on which
+// case the returned instance should be ignored.
+func NewNodeRecorder(nodeName string, capacity int, timestamper Timestamper) (*NodeRecorder, error) {
+	if nodeName == "" {
+		return nil, ErrMissingNode
+	}
+	if capacity < 1 {
+		return nil, ErrInvalidCapacity
+	}
+	nr := NodeRecorder{
+		timestamper: timestamper,
+		nodeName:    nodeName,
+		capacity:    capacity,
+	}
+	if capacity == 1 { // handle common special case
+		nr.statuses = make([]RecordedStatus, 1)
+	}
+	return &nr, nil
+}
+
+// Push adds a new Status to the record, evicting the oldest Status if necessary.
+// The pushed status is a full independent copy of the provided Status.
+// If the Status added is inconsistent, returns an error detailing the reason.
+// Statuses are evicted only in case of success.
+func (nr *NodeRecorder) Push(st podfingerprint.Status) error {
+	if st.NodeName == "" {
+		return ErrMissingNode
+	}
+	if st.NodeName != nr.nodeName {
+		return ErrMismatchingNode
+	}
+	if nr.capacity == 1 { // handle common special case, avoid any resize
+		nr.statuses[0] = RecordedStatus{
+			Status:     st.Clone(),
+			RecordTime: nr.timestamper(),
+		}
+		return nil
+	}
+	if nr.Len() == nr.Cap() {
+		// drop the older sample
+		nr.statuses = nr.statuses[1:]
+	}
+	nr.statuses = append(nr.statuses, RecordedStatus{
+		Status:     st.Clone(),
+		RecordTime: nr.timestamper(),
+	})
+	return nil
+}
+
+// Len returns how many Statuses are currently held in the NodeRecorder
+func (nr *NodeRecorder) Len() int {
+	return len(nr.statuses)
+}
+
+// Cap returns the maximum capacity of the NodeRecorder
+func (nr *NodeRecorder) Cap() int {
+	return nr.capacity
+}
+
+// Content() returns a shallow copy of all the recorded statuses.
+func (nr *NodeRecorder) Content() []RecordedStatus {
+	return nr.statuses
+}
+
+// Recorder stores all the recorded statuses, dividing them by node name.
+// There is a hard cap of how many nodes are managed, and how many Statuses are recorded per node.
+type Recorder struct {
+	nodes        map[string]*NodeRecorder
+	nodeCapacity int
+	maxNodes     int
+	timestamper  Timestamper
+}
+
+// NewRecorder creates a new recorder up to the given node count, each with the given capacity.
+// Each per-node recorder is a ring buffer, so only the latest <nodeCapacity> Statuses are kept
+// at any time for each node. The per-node records are created lazily as needed.
+// The timestamper callback is used to mark times. Use `time.Now` if unsure.
+// Returns the newly created instance; if parameters are incorrect, returns an error, on which
+// case the returned instance should be ignored.
+func NewRecorder(maxNodes, nodeCapacity int, timestamper Timestamper) (*Recorder, error) {
+	if maxNodes < 1 {
+		return nil, ErrInvalidNodeCount
+	}
+	if nodeCapacity < 1 {
+		return nil, ErrInvalidCapacity
+	}
+	return &Recorder{
+		nodes:        make(map[string]*NodeRecorder),
+		nodeCapacity: nodeCapacity,
+		maxNodes:     maxNodes,
+		timestamper:  timestamper,
+	}, nil
+}
+
+// Cap returns the maximum nodes allowed in this Recorder
+func (rr *Recorder) MaxNodes() int {
+	return rr.maxNodes
+}
+
+// Cap returns the maximum capacity of each NodeRecorder
+func (rr *Recorder) Cap() int {
+	return rr.nodeCapacity
+}
+
+// CountNodes returns how many Nodes are known to the Recorder
+func (rr *Recorder) CountNodes() int {
+	return len(rr.nodes)
+}
+
+// CountRecords returns how many Records are held for the give nodeName in the Recorder
+func (rr *Recorder) CountRecords(nodeName string) int {
+	nr, ok := rr.nodes[nodeName]
+	if !ok {
+		return 0
+	}
+	return nr.Len()
+}
+
+// Len returns the total number of records across all nodes
+func (rr *Recorder) Len() int {
+	tot := 0
+	for _, nr := range rr.nodes {
+		tot += nr.Len()
+	}
+	return tot
+}
+
+// Push adds a new Status to the record for its node, evicting the oldest Status
+// belonging to the same node if necessary.
+// Per-node records are created lazily as needed, up to the configured maximum.
+// The pushed status is a full independent copy of the provided Status.
+// If the Status added is inconsistent, returns an error detailing the reason.
+// Statuses are evicted only in case of success.
+func (rr *Recorder) Push(st podfingerprint.Status) error {
+	if st.NodeName == "" {
+		return ErrMissingNode
+	}
+	if len(rr.nodes) >= rr.maxNodes {
+		return ErrTooManyNodes
+	}
+	var err error
+	nr, ok := rr.nodes[st.NodeName]
+	if !ok {
+		nr, err = NewNodeRecorder(st.NodeName, rr.nodeCapacity, rr.timestamper)
+		if err != nil {
+			return err
+		}
+		rr.nodes[st.NodeName] = nr
+	}
+	return nr.Push(st)
+}
+
+// Content() returns a shallow copy of all the recorded statuses, by node name.
+func (rr *Recorder) Content() map[string][]RecordedStatus {
+	ret := make(map[string][]RecordedStatus, len(rr.nodes))
+	for nodeName, nr := range rr.nodes {
+		ret[nodeName] = nr.Content()
+	}
+	return ret
+}
+
+// ContentForNode returns a shallow copy of all the recorded status for the given nodeName.
+// Returns the content and a boolean which tells if the node is known or not
+func (rr *Recorder) ContentForNode(nodeName string) ([]RecordedStatus, bool) {
+	nr, ok := rr.nodes[nodeName]
+	if !ok {
+		return []RecordedStatus{}, false
+	}
+	return nr.Content(), true
+}

--- a/vendor/github.com/k8stopologyawareschedwg/podfingerprint/tracing.go
+++ b/vendor/github.com/k8stopologyawareschedwg/podfingerprint/tracing.go
@@ -18,6 +18,7 @@ package podfingerprint
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -66,6 +67,25 @@ type Status struct {
 	FingerprintComputed string           `json:"fingerprintComputed,omitempty"`
 	Pods                []NamespacedName `json:"pods,omitempty"`
 	NodeName            string           `json:"nodeName,omitempty"`
+}
+
+func (s Status) Equal(x Status) bool {
+	if s.NodeName != x.NodeName {
+		return false
+	}
+	if s.FingerprintExpected != x.FingerprintExpected {
+		return false
+	}
+	if s.FingerprintComputed != x.FingerprintComputed {
+		return false
+	}
+	if len(s.Pods) != len(x.Pods) {
+		return false
+	}
+	if len(s.Pods) > 0 && !reflect.DeepEqual(s.Pods, x.Pods) {
+		return false
+	}
+	return true
 }
 
 func MakeStatus(nodeName string) Status {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,9 +178,10 @@ github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/attribute
 github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha2/helper/numanode
-# github.com/k8stopologyawareschedwg/podfingerprint v0.2.2
-## explicit; go 1.17
+# github.com/k8stopologyawareschedwg/podfingerprint v0.2.3-0.20250917082921-b1753a88551b => github.com/k8stopologyawareschedwg/podfingerprint v0.2.3-0.20250917082921-b1753a88551b
+## explicit; go 1.22
 github.com/k8stopologyawareschedwg/podfingerprint
+github.com/k8stopologyawareschedwg/podfingerprint/record
 # github.com/kylelemons/godebug v1.1.0
 ## explicit; go 1.11
 github.com/kylelemons/godebug/diff
@@ -1674,3 +1675,4 @@ sigs.k8s.io/yaml/goyaml.v2
 # k8s.io/externaljwt => k8s.io/externaljwt v0.33.3
 # k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.33.3
 # k8s.io/sample-controller => k8s.io/sample-controller v0.33.3
+# github.com/k8stopologyawareschedwg/podfingerprint => github.com/k8stopologyawareschedwg/podfingerprint v0.2.3-0.20250917082921-b1753a88551b


### PR DESCRIPTION
When exposing pfpstatus data, dumping to files was fallback because we couldn't find a quick way to expose the data using HTTP in a secure way.

Things are  slowly changing, so this PR explores the option to add a HTTP endpoint to inspect the pfpstatus.

The internal collection must be extremely cheap, but the publication of data doesn't need to be so cheap (but still must be as lightweight as possible), because
is done very sporadically when troubleshooting, possibly just once in a while using must-gather.

The only main remaining blocker is how to secure
the new endpoint using kube/OCP primitives.
