### PR TITLE
[KNI] main: configure coalescing PFP recorder

### DIFF
--- a/cmd/noderesourcetopology-plugin/main.go
+++ b/cmd/noderesourcetopology-plugin/main.go
@@ -50,6 +50,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	pfpStatusParams := knistatus.DefaultParams()
+	pfpStatusParams.Storage.CoalesceLast = true
 	knistatus.ParamsFromEnv(logh, &pfpStatusParams)
 	knistatus.Setup(logh, pfpStatusParams)
 


### PR DESCRIPTION
The recorder by default pushes every new status as long as some capacity constraints are met but it doesn't check whether this status is already reported last. We added option to configure the coalesing on the recorder and by default it is false so we don't limit any client from pushing the same PFPs again. Here we only set this param to true at the begining of the program without need to set it through env var because this is what we expect when the scheduler is recording the statuses.

