### PR TITLE
[release-4.20] [KNI] chore(KONFLUX-6210): fix and set name and cpe label in dockerfile

### DIFF
--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /bin
 CMD ["kube-scheduler"]
 
 LABEL com.redhat.component="noderesourcetopology-scheduler-container" \
-      name="openshift4/noderesourcetopology-scheduler" \
+      name="openshift4/noderesourcetopology-scheduler-rhel9" \
       summary="node resource topology aware scheduler" \
       io.openshift.expose-services="" \
       io.openshift.tags="numa,topology,scheduler" \
@@ -27,5 +27,6 @@ LABEL com.redhat.component="noderesourcetopology-scheduler-container" \
       maintainer="openshift-operators@redhat.com" \
       io.openshift.maintainer.component="Node Resource Topology aware Scheduler" \
       io.openshift.maintainer.product="OpenShift Container Platform" \
-      io.k8s.description="Node Resource Topology aware Scheduler"
+      io.k8s.description="Node Resource Topology aware Scheduler" \
+      cpe="cpe:/a:redhat:openshift:4.20::el9"
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements. See also release-engineering/rhtap-ec-policy#149

