### PR TITLE
[KNI] redirect to stable branch

### DIFF
--- a/.tekton/noderesourcetopology-scheduler-4-21-pull-request.yaml
+++ b/.tekton/noderesourcetopology-scheduler-4-21-pull-request.yaml
@@ -8,8 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-4.21"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: noderesourcetopology-scheduler-4-21

--- a/.tekton/noderesourcetopology-scheduler-4-21-push.yaml
+++ b/.tekton/noderesourcetopology-scheduler-4-21-push.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-4.21"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: noderesourcetopology-scheduler-4-21

--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -3,7 +3,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24
 
 ARG COMMIT_SHA
 ARG OCP_MAJOR_VERSION=4
-ARG OCP_MINOR_VERSION=20
+ARG OCP_MINOR_VERSION=21
 
 WORKDIR /app
 


### PR DESCRIPTION
4.21 is branched out, so we should point to the release branch
