### PR TITLE
[KNI] d/s: add `url` label

### DIFF
--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -28,4 +28,5 @@ LABEL com.redhat.component="noderesourcetopology-scheduler-container" \
       io.openshift.maintainer.component="Node Resource Topology aware Scheduler" \
       io.openshift.maintainer.product="OpenShift Container Platform" \
       io.k8s.description="Node Resource Topology aware Scheduler" \
-      cpe="cpe:/a:redhat:openshift:4.22::el9"
+      cpe="cpe:/a:redhat:openshift:4.22::el9" \
+      url="https://github.com/konflux-io/noderesourcetopology-plugin"


### PR DESCRIPTION
The label is being used by automation to generate konflux CR snapshots, when not set, all redhat generated images point to stage registry:

```
skopeo inspect docker://quay.io/redhat-user-workloads/telco-5g-tenant/noderesourcetopology-scheduler-4-21@sha256:b2260d0e82ab8a39e0fdf280bed9286fbd4ace3087305096928ca76e345c07ba --authfile pull_secret.json

"Labels": {
...
	"url": "https://catalog.redhat.com/en/search?searchType=containers",
...
}
```
