### PR TITLE
[release-4.12] ci: Fix setup-envtest GCS 401 error by upgrading to release-0.17

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.5
+          go-version: 1.20.0
 
       - name: Run integration test
         run:

--- a/hack-kni/install-envtest.sh
+++ b/hack-kni/install-envtest.sh
@@ -32,7 +32,8 @@ version=$(cat ${SCRIPT_ROOT}/go.mod | grep 'k8s.io/kubernetes' | grep -v '=>' | 
 
 GOPATH=$(go env GOPATH)
 TEMP_DIR=${TMPDIR-/tmp}
-# this is the last version before the bump golang 1.20 -> 1.22. We want to avoid the go.mod version format changes - for now.
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230927023946-553bd00cfec5
-"${GOPATH}"/bin/setup-envtest use -p env "${version}" > "${TEMP_DIR}/setup-envtest"
-
+# Use release-0.17 (Go 1.20) which has the controller-tools index support.
+# The old GCS bucket is deprecated and returns 401/403.
+# See: https://github.com/kubernetes-sigs/kubebuilder/discussions/4082
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
+"${GOPATH}"/bin/setup-envtest use --use-deprecated-gcs=false -p env "${version}" > "${TEMP_DIR}/setup-envtest"


### PR DESCRIPTION
The old GCS bucket (storage.googleapis.com/kubebuilder-tools) used by setup-envtest is deprecated and now returns 401/403 for all requests. Update setup-envtest to release-0.17 which supports downloading envtest binaries from the new controller-tools GitHub releases index, and pass --use-deprecated-gcs=false to use it. Bump Go to 1.20 in the integration-test CI job as required by setup-envtest release-0.17.

See: https://github.com/kubernetes-sigs/kubebuilder/discussions/4082
