### PR TITLE
[release-4.16] [KNI] bump setup-envtest to release-0.19

### DIFF
--- a/hack-kni/install-envtest.sh
+++ b/hack-kni/install-envtest.sh
@@ -33,6 +33,6 @@ version=$(cat ${SCRIPT_ROOT}/go.mod | grep 'k8s.io/kubernetes' | grep -v '=>' | 
 GOPATH=$(go env GOPATH)
 TEMP_DIR=${TMPDIR-/tmp}
 # this is the last version before the bump golang 1.20 -> 1.22. We want to avoid the go.mod version format changes - for now.
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230927023946-553bd00cfec5
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
 "${GOPATH}"/bin/setup-envtest use -p env "${version}" > "${TEMP_DIR}/setup-envtest"
 


### PR DESCRIPTION
Supersedes #1563 (corrected commit message).

The GCS bucket (storage.googleapis.com/kubebuilder-tools) used by
setup-envtest release-0.18 and lower to download envtest binaries is deprecated
and now returns 401 Unauthorized, causing controller tests to fail.

Release-0.19 downloads binaries from the new location (GitHub releases)
as recommended by the kubebuilder maintainers.

Ref: kubernetes-sigs/kubebuilder#4082

Made with [Cursor](https://cursor.com)