### PR TITLE
[release-4.14] [KNI] bump CI go version to 1.22 and setup-envtest to release-0.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.7
+          go-version: '1.22'
 
       - name: Run integration test
         run:

--- a/hack-kni/install-envtest.sh
+++ b/hack-kni/install-envtest.sh
@@ -32,7 +32,9 @@ version=$(cat ${SCRIPT_ROOT}/go.mod | grep 'k8s.io/kubernetes' | grep -v '=>' | 
 
 GOPATH=$(go env GOPATH)
 TEMP_DIR=${TMPDIR-/tmp}
-# this is the last version before the bump golang 1.20 -> 1.22. We want to avoid the go.mod version format changes - for now.
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230927023946-553bd00cfec5
+# release-0.19 is required to download envtest binaries from the new location
+# (controller-tools releases) since the old GCS bucket is deprecated.
+# NOTE: release-0.19's go.mod uses "go 1.22.0" (three-part format), so Go >= 1.21 is needed.
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
 "${GOPATH}"/bin/setup-envtest use -p env "${version}" > "${TEMP_DIR}/setup-envtest"
 


### PR DESCRIPTION
The GCS bucket (storage.googleapis.com/kubebuilder-tools) used by
setup-envtest release-0.18 and lower to download envtest binaries is deprecated
and now returns 401 Unauthorized, causing controller tests to fail.

Release-0.19 downloads binaries from the new location (GitHub releases)
as recommended by the kubebuilder maintainers.

However, release-0.19's go.mod uses the three-part "go 1.22.0" directive
format, which Go < 1.21 cannot parse. Bump the integration-test CI job
from Go 1.20.7 to Go 1.22 to resolve this. Go 1.22 is fully backward-
compatible and can build go 1.20 modules without issues.

Ref: kubernetes-sigs/kubebuilder#4082

Made-with: Cursor
