### PR TITLE
Add fontivan and by2waysprojects to konflux-approvers (release-4.20)

### DIFF
--- a/DOWNSTREAM_OWNERS_ALIASES
+++ b/DOWNSTREAM_OWNERS_ALIASES
@@ -13,3 +13,5 @@ aliases:
   konflux-approvers:
     - yanirq
     - shajmakh
+    - fontivan
+    - by2waysprojects


### PR DESCRIPTION
## Summary
- Adds `fontivan` and `by2waysprojects` to the `konflux-approvers` alias in `DOWNSTREAM_OWNERS_ALIASES`

## Test plan
- Verify YAML syntax is correct
- Verify new users appear under `konflux-approvers`


Made with [Cursor](https://cursor.com)