### PR TITLE
[KNI] Fix url label in konflux.Dockerfile

### DIFF
--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -29,4 +29,4 @@ LABEL com.redhat.component="noderesourcetopology-scheduler-container" \
       io.openshift.maintainer.product="OpenShift Container Platform" \
       io.k8s.description="Node Resource Topology aware Scheduler" \
       cpe="cpe:/a:redhat:openshift:5.0::el9" \
-      url="https://github.com/konflux-io/noderesourcetopology-plugin"
+      url="https://github.com/openshift-kni/scheduler-plugins"


### PR DESCRIPTION
## Summary
- Fix the `url` label in `build/noderesourcetopology-plugin/konflux.Dockerfile` to point to `https://github.com/openshift-kni/scheduler-plugins` instead of the obsolete `konflux-io/noderesourcetopology-plugin` repo.

## Test plan
- Verify the Dockerfile builds correctly with the updated label.

Made with [Cursor](https://cursor.com)