### PR TITLE
CNF-26428: [KNI] dockerfile: use PQC base images

### DIFF
--- a/build/noderesourcetopology-plugin/Dockerfile
+++ b/build/noderesourcetopology-plugin/Dockerfile
@@ -20,7 +20,7 @@ COPY . .
 ARG RELEASE_VERSION
 RUN RELEASE_VERSION=${RELEASE_VERSION} make -f Makefile.kni build-noderesourcetopology-plugin
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc
 COPY --from=builder /go/src/sigs.k8s.io/scheduler-plugins/bin/noderesourcetopology-plugin /bin/kube-scheduler
 USER 65532:65532
 WORKDIR /bin

--- a/build/noderesourcetopology-plugin/Dockerfile.openshift
+++ b/build/noderesourcetopology-plugin/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc
 COPY noderesourcetopology-plugin /bin/kube-scheduler
 USER 65532:65532
 WORKDIR /bin

--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 RUN GOEXPERIMENT=strictfipsruntime GOOS=linux CGO_ENABLED=1 go build -ldflags "-X k8s.io/component-base/version.gitMajor=${OCP_MAJOR_VERSION} -X k8s.io/component-base/version.gitMinor=${OCP_MINOR_VERSION} -X k8s.io/component-base/version.gitCommit=${COMMIT_SHA}  -w" -tags strictfipsruntime -o bin/noderesourcetopology-plugin cmd/noderesourcetopology-plugin/main.go
 
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:7c372902c8d211db2d25c8277ba534a73b92742a334874dced829a63b0f21221
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc@sha256:8eb7f73635df6505791633845ed65e6e804b7b3f54c49f8ffb7d04b8f31a7c91
 
 COPY --from=builder /app/bin/noderesourcetopology-plugin /bin/kube-scheduler
 WORKDIR /bin


### PR DESCRIPTION
Switch the Konflux runtime base image from ubi-minimal to ubi-minimal-pqc to enable the DEFAULT:PQ crypto-policy in the container, as required by [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113) for platform-wide PQC consistency.
The PQC base images use the DEFAULT:PQ crypto-policy instead of DEFAULT, enabling post-quantum algorithms (ML-KEM, ML-DSA) in OpenSSL.
