### PR TITLE
[KNI] CNF-26586: update container image name from openshift4 to openshift5

### DIFF
--- a/build/noderesourcetopology-plugin/konflux.Dockerfile
+++ b/build/noderesourcetopology-plugin/konflux.Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /bin
 CMD ["kube-scheduler"]
 
 LABEL com.redhat.component="noderesourcetopology-scheduler-container" \
-      name="openshift4/noderesourcetopology-scheduler-rhel9" \
+      name="openshift5/noderesourcetopology-scheduler-rhel9" \
       summary="node resource topology aware scheduler" \
       io.openshift.expose-services="" \
       io.openshift.tags="numa,topology,scheduler" \


### PR DESCRIPTION
## Summary
- Update the LABEL `name` field in `build/noderesourcetopology-plugin/konflux.Dockerfile` from `openshift4/noderesourcetopology-scheduler-rhel9` to `openshift5/noderesourcetopology-scheduler-rhel9`
- The rest of the Dockerfile already targets OCP 5.0 (`OCP_MAJOR_VERSION=5`, `cpe` with `openshift:5.0`), but this label was still referencing the old `openshift4` registry path

## Test plan
- [ ] Verify the Konflux pipeline builds successfully with the updated image name
- [ ] Confirm the resulting container image metadata reflects `openshift5`

Jira: https://redhat.atlassian.net/browse/CNF-26586

Made with [Cursor](https://cursor.com)